### PR TITLE
support remaining `signInWith...` methods

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 
 class MockFirebaseAuth extends Mock implements FirebaseAuth {
@@ -19,6 +20,27 @@ class MockFirebaseAuth extends Mock implements FirebaseAuth {
 
   @override
   Future<AuthResult> signInWithCredential(AuthCredential credential) {
+    return _fakeSignIn();
+  }
+
+  @override
+  Future<AuthResult> signInWithEmailAndPassword({
+    @required String email,
+    @required String password,
+  }) {
+    return _fakeSignIn();
+  }
+
+  @override
+  Future<AuthResult> signInWithEmailAndLink({String email, String link}) {
+    return _fakeSignIn();
+  }
+
+  @override Future<AuthResult> signInWithCustomToken({@required String token}) {
+    return _fakeSignIn();
+  }
+
+  Future<AuthResult> _fakeSignIn() {
     final authResult = MockAuthResult();
     _currentUser = authResult.user;
     stateChangedStreamController.add(_currentUser);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_auth: ^0.15.2
+  meta: ^1.1.8
   mockito: ^4.1.0
 
 dev_dependencies:

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -10,14 +10,42 @@ void main() {
     expect(user, isNull);
   });
 
-  test('Returns a hardcoded user after sign in', () async {
-    final auth = MockFirebaseAuth();
-    // Credentials would typically come from GoogleSignIn.
-    final credential = FakeAuthCredential();
-    final result = await auth.signInWithCredential(credential);
-    final user = await result.user;
-    expect(user.uid, isNotEmpty);
-    expect(user.displayName, isNotEmpty);
+  group('Returns a hardcoded user after sign in', () {
+    test('with Credential', () async {
+      final auth = MockFirebaseAuth();
+      // Credentials would typically come from GoogleSignIn.
+      final credential = FakeAuthCredential();
+      final result = await auth.signInWithCredential(credential);
+      final user = await result.user;
+      expect(user.uid, isNotEmpty);
+      expect(user.displayName, isNotEmpty);
+    });
+
+    test('with email and password', () async {
+      final auth = MockFirebaseAuth();
+      final result = await auth.signInWithEmailAndPassword(
+          email: 'some email', password: 'some password');
+      final user = await result.user;
+      expect(user.uid, isNotEmpty);
+      expect(user.displayName, isNotEmpty);
+    });
+
+    test('with email and link', () async {
+      final auth = MockFirebaseAuth();
+      final result = await auth.signInWithEmailAndLink(
+          email: 'some email', link: 'some link');
+      final user = await result.user;
+      expect(user.uid, isNotEmpty);
+      expect(user.displayName, isNotEmpty);
+    });
+
+    test('with token', () async {
+      final auth = MockFirebaseAuth();
+      final result = await auth.signInWithCustomToken(token: 'some token');
+      final user = await result.user;
+      expect(user.uid, isNotEmpty);
+      expect(user.displayName, isNotEmpty);
+    });
   });
 
   test('Returns a hardcoded user if already signed in', () async {


### PR DESCRIPTION
Added support for:
* signInWithEmailAndPassword
* signInWithEmailAndLink
* signInWithCustomToken