### PR TITLE
Remove onAuthStateChanged in favor of authStateChanges()

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -58,6 +58,6 @@ class MockFirebaseAuth extends Mock implements FirebaseAuth {
   }
 
   @override
-  Stream<User> get onAuthStateChanged =>
+  Stream<User> authStateChanges() =>
       stateChangedStreamController.stream;
 }

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -19,10 +19,10 @@ void main() {
       final user = await result.user;
       expect(user.uid, isNotEmpty);
       expect(user.displayName, isNotEmpty);
-      expect(auth.onAuthStateChanged, emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
       expect(user.isAnonymous, isFalse);
     });
-  return;
+
     test('with email and password', () async {
       final auth = MockFirebaseAuth();
       final result = await auth.signInWithEmailAndPassword(
@@ -30,7 +30,7 @@ void main() {
       final user = await result.user;
       expect(user.uid, isNotEmpty);
       expect(user.displayName, isNotEmpty);
-      expect(auth.onAuthStateChanged, emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
     });
 
     test('with token', () async {
@@ -39,7 +39,7 @@ void main() {
       final user = await result.user;
       expect(user.uid, isNotEmpty);
       expect(user.displayName, isNotEmpty);
-      expect(auth.onAuthStateChanged, emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
     });
 
     test('anonymously', () async {
@@ -47,7 +47,7 @@ void main() {
       final result = await auth.signInAnonymously();
       final user = await result.user;
       expect(user.uid, isNotEmpty);
-      expect(auth.onAuthStateChanged, emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
       expect(user.isAnonymous, isTrue);
     });
   });
@@ -73,7 +73,7 @@ void main() {
     await auth.signOut();
 
     expect(auth.currentUser, isNull);
-    expect(auth.onAuthStateChanged, emitsInOrder([user, null]));
+    expect(auth.authStateChanges(), emitsInOrder([user, null]));
   });
 }
 


### PR DESCRIPTION
Renames `get onAuthStateChanged` to `authStateChanges()` as in firebase_auth's 0.18.0 release and therefore should resolve #19 