### PR TITLE
FIX: Update firebase_auth to latest version(0.20.0+1)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_auth: ^0.18.0+1
+  firebase_auth: ^0.20.0+1
   meta: ^1.1.8
   mockito: ^4.1.0
 


### PR DESCRIPTION
Due to version conflict, the Firebase_auth version in which the package depend on was updated to the latest(0.20.0+1) to fix the version issue when the package was used along side Firebase_auth