### PR TITLE
Allow custom MockUser to be specified

### DIFF
--- a/lib/firebase_auth_mocks.dart
+++ b/lib/firebase_auth_mocks.dart
@@ -4,3 +4,4 @@
 library firebase_auth_mocks;
 
 export 'src/firebase_auth_mocks_base.dart';
+export 'src/mock_user.dart';

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -4,13 +4,16 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 
+import '../firebase_auth_mocks.dart';
 import 'mock_user_credential.dart';
 
 class MockFirebaseAuth extends Mock implements FirebaseAuth {
   final stateChangedStreamController = StreamController<User>();
+  final MockUser _mockUser;
   User _currentUser;
 
-  MockFirebaseAuth({signedIn = false}) {
+  MockFirebaseAuth({signedIn = false, MockUser mockUser})
+      : _mockUser = mockUser {
     if (signedIn) {
       signInWithCredential(null);
     }
@@ -50,14 +53,14 @@ class MockFirebaseAuth extends Mock implements FirebaseAuth {
     stateChangedStreamController.add(null);
   }
 
-  Future<UserCredential> _fakeSignIn({ bool isAnonymous = false }) {
-    final userCredential = MockUserCredential(isAnonymous: isAnonymous);
+  Future<UserCredential> _fakeSignIn({bool isAnonymous = false}) {
+    final userCredential =
+        MockUserCredential(isAnonymous: isAnonymous, mockUser: _mockUser);
     _currentUser = userCredential.user;
     stateChangedStreamController.add(_currentUser);
     return Future.value(userCredential);
   }
 
   @override
-  Stream<User> authStateChanges() =>
-      stateChangedStreamController.stream;
+  Stream<User> authStateChanges() => stateChangedStreamController.stream;
 }

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -3,23 +3,73 @@ import 'package:mockito/mockito.dart';
 
 class MockUser extends Mock implements User {
   final bool _isAnonymous;
+  final String _uid;
+  final String _email;
+  final String _displayName;
+  final String _phoneNumber;
+  final String _photoURL;
+  final String _refreshToken;
 
-  MockUser({bool isAnonymous}) : _isAnonymous = isAnonymous;
-
-  @override
-  String get displayName => 'Bob';
-
-  @override
-  String get uid => 'aabbcc';
-
-  @override
-  String get email => 'bob@somedomain.com';
+  MockUser({
+    isAnonymous = false,
+    uid = 'some_random_id',
+    email,
+    displayName,
+    phoneNumber,
+    photoURL,
+    refreshToken,
+  })  : _isAnonymous = isAnonymous,
+        _uid = uid,
+        _email = email,
+        _displayName = displayName,
+        _phoneNumber = phoneNumber,
+        _photoURL = photoURL,
+        _refreshToken = refreshToken;
 
   @override
   bool get isAnonymous => _isAnonymous;
 
   @override
+  String get uid => _uid;
+
+  @override
+  String get email => _email;
+
+  @override
+  String get displayName => _displayName;
+
+  @override
+  String get phoneNumber => _phoneNumber;
+
+  @override
+  String get photoURL => _photoURL;
+
+  @override
+  String get refreshToken => _refreshToken;
+
+  @override
   Future<String> getIdToken([bool forceRefresh = false]) async {
     return Future.value('fake_token');
   }
+
+  @override
+  bool operator ==(o) =>
+      o is User &&
+      _isAnonymous == o.isAnonymous &&
+      _uid == o.uid &&
+      _email == o.email &&
+      _displayName == o.displayName &&
+      _phoneNumber == o.phoneNumber &&
+      _photoURL == o.photoURL &&
+      _refreshToken == o.refreshToken;
+
+  @override
+  int get hashCode =>
+      _isAnonymous.hashCode ^
+      _uid.hashCode ^
+      _email.hashCode ^
+      _displayName.hashCode ^
+      _phoneNumber.hashCode ^
+      _photoURL.hashCode ^
+      _refreshToken.hashCode;
 }

--- a/lib/src/mock_user_credential.dart
+++ b/lib/src/mock_user_credential.dart
@@ -5,9 +5,14 @@ import 'mock_user.dart';
 
 class MockUserCredential extends Mock implements UserCredential {
   final bool _isAnonymous;
+  final MockUser _mockUser;
 
-  MockUserCredential({bool isAnonymous}) : _isAnonymous = isAnonymous;
+  MockUserCredential({bool isAnonymous, MockUser mockUser})
+      // Ensure no mocked credentials or mocked for Anonymous
+      : assert(mockUser == null || mockUser.isAnonymous == isAnonymous),
+        _isAnonymous = isAnonymous,
+        _mockUser = mockUser;
 
   @override
-  User get user => MockUser(isAnonymous: _isAnonymous);
+  User get user => _mockUser ?? MockUser(isAnonymous: _isAnonymous);
 }

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -3,6 +3,16 @@ import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+final tUser = MockUser(
+  isAnonymous: false,
+  uid: 'T3STU1D',
+  email: 'bob@thebuilder.com',
+  displayName: 'Bob Builder',
+  phoneNumber: '0800 I CAN FIX IT',
+  photoURL: 'http://photos.url/bobbie.jpg',
+  refreshToken: 'some_long_token',
+);
+
 void main() {
   test('Returns no user if not signed in', () async {
     final auth = MockFirebaseAuth();
@@ -10,35 +20,32 @@ void main() {
     expect(user, isNull);
   });
 
-  group('Returns a hardcoded user after sign in', () {
+  group('Returns a mocked user user after sign in', () {
     test('with Credential', () async {
-      final auth = MockFirebaseAuth();
+      final auth = MockFirebaseAuth(mockUser: tUser);
       // Credentials would typically come from GoogleSignIn.
       final credential = FakeAuthCredential();
       final result = await auth.signInWithCredential(credential);
       final user = await result.user;
-      expect(user.uid, isNotEmpty);
-      expect(user.displayName, isNotEmpty);
+      expect(user, tUser);
       expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
       expect(user.isAnonymous, isFalse);
     });
 
     test('with email and password', () async {
-      final auth = MockFirebaseAuth();
+      final auth = MockFirebaseAuth(mockUser: tUser);
       final result = await auth.signInWithEmailAndPassword(
           email: 'some email', password: 'some password');
       final user = await result.user;
-      expect(user.uid, isNotEmpty);
-      expect(user.displayName, isNotEmpty);
+      expect(user, tUser);
       expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
     });
 
     test('with token', () async {
-      final auth = MockFirebaseAuth();
+      final auth = MockFirebaseAuth(mockUser: tUser);
       final result = await auth.signInWithCustomToken('some token');
       final user = await result.user;
-      expect(user.uid, isNotEmpty);
-      expect(user.displayName, isNotEmpty);
+      expect(user, tUser);
       expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
     });
 
@@ -52,22 +59,21 @@ void main() {
     });
   });
 
-  test('Returns a hardcoded user if already signed in', () async {
-    final auth = MockFirebaseAuth(signedIn: true);
+  test('Returns a mocked user if already signed in', () async {
+    final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
     final user = auth.currentUser;
-    expect(user.uid, isNotEmpty);
-    expect(user.displayName, isNotEmpty);
+    expect(user, tUser);
   });
 
   test('Returns a hardcoded user token', () async {
-    final auth = MockFirebaseAuth(signedIn: true);
+    final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
     final user = auth.currentUser;
     final idToken = await user.getIdToken();
     expect(idToken, isNotEmpty);
   });
 
   test('Returns null after sign out', () async {
-    final auth = MockFirebaseAuth(signedIn: true);
+    final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
     final user = auth.currentUser;
 
     await auth.signOut();


### PR DESCRIPTION
Extra fields added to `MockUser`
You can now supply a `MockUser` for authentication.