### PR TITLE
fixed sending null when signIn is false

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -17,6 +17,8 @@ class MockFirebaseAuth extends Mock implements FirebaseAuth {
       : _mockUser = mockUser {
     if (signedIn) {
       signInWithCredential(null);
+    } else {
+      stateChangedStreamController.add(null);
     }
   }
 


### PR DESCRIPTION
Firebase auth has an initial value in the stream, either null or a credential depending on signIn. Currently, this mock doesn't send a null if the user isn't signed in.