### PR TITLE
Reflecting Firebase Non-nullable values within MockUser 

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -11,8 +11,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   final MockUser? _mockUser;
   User? _currentUser;
 
-  MockFirebaseAuth({signedIn = false, MockUser? mockUser})
-      : _mockUser = mockUser {
+  MockFirebaseAuth({signedIn = false, MockUser? mockUser}) : _mockUser = mockUser {
     if (signedIn) {
       signInWithCredential(null);
     }
@@ -42,8 +41,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   }
 
   @override
-  Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber,
-      [RecaptchaVerifier? verifier]) async {
+  Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber, [RecaptchaVerifier? verifier]) async {
     return MockConfirmationResult(onConfirm: () => _fakeSignIn());
   }
 
@@ -59,8 +57,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   }
 
   Future<UserCredential> _fakeSignIn({bool isAnonymous = false}) {
-    final userCredential =
-        MockUserCredential(isAnonymous: isAnonymous, mockUser: _mockUser);
+    final userCredential = MockUserCredential(isAnonymous, mockUser: _mockUser);
     _currentUser = userCredential.user;
     stateChangedStreamController.add(_currentUser);
     return Future.value(userCredential);

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -2,32 +2,41 @@ import 'package:equatable/equatable.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 class MockUser with EquatableMixin implements User {
-  final bool? _isAnonymous;
+  final bool _isAnonymous;
+  final bool _isEmailVerified;
   final String _uid;
   final String? _email;
   final String? _displayName;
   final String? _phoneNumber;
   final String? _photoURL;
   final String? _refreshToken;
+  final UserMetadata? _metadata;
 
   MockUser({
-    bool? isAnonymous = false,
+    bool isAnonymous = false,
+    bool isEmailVerified = true,
     String uid = 'some_random_id',
     String? email,
     String? displayName,
     String? phoneNumber,
     String? photoURL,
     String? refreshToken,
+    UserMetadata? metadata,
   })  : _isAnonymous = isAnonymous,
+        _isEmailVerified = isEmailVerified,
         _uid = uid,
         _email = email,
         _displayName = displayName,
         _phoneNumber = phoneNumber,
         _photoURL = photoURL,
-        _refreshToken = refreshToken;
+        _refreshToken = refreshToken,
+        _metadata = metadata;
 
   @override
-  bool get isAnonymous => _isAnonymous!;
+  bool get isAnonymous => _isAnonymous;
+
+  @override
+  bool get emailVerified => _isEmailVerified;
 
   @override
   String get uid => _uid;
@@ -53,6 +62,9 @@ class MockUser with EquatableMixin implements User {
   }
 
   @override
+  UserMetadata get metadata => _metadata ?? UserMetadata(0, 0);
+
+  @override
   List<Object?> get props => [
         _isAnonymous,
         _uid,
@@ -61,6 +73,7 @@ class MockUser with EquatableMixin implements User {
         _phoneNumber,
         _photoURL,
         _refreshToken,
+        _metadata,
       ];
 
   @override

--- a/lib/src/mock_user_credential.dart
+++ b/lib/src/mock_user_credential.dart
@@ -3,10 +3,10 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'mock_user.dart';
 
 class MockUserCredential implements UserCredential {
-  final bool? _isAnonymous;
+  final bool _isAnonymous;
   final MockUser? _mockUser;
 
-  MockUserCredential({bool? isAnonymous, MockUser? mockUser})
+  MockUserCredential(bool isAnonymous, {MockUser? mockUser})
       // Ensure no mocked credentials or mocked for Anonymous
       : assert(mockUser == null || mockUser.isAnonymous == isAnonymous),
         _isAnonymous = isAnonymous,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_auth_mocks
 description: Fakes for Firebase Auth. Use this package with `google_sign_in_mocks` to write unit tests involving Firebase Authentication.
-version: 0.7.0
+version: 0.8.0
 homepage: http://blog.wafrat.com
 repository: https://github.com/atn832/firebase_auth_mocks
 
@@ -17,5 +17,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.0.0
+  pedantic: ^1.11.0
   test: ^1.0.0


### PR DESCRIPTION
Firebase Auth User class contains non-nullable values, I believe we should reflect this within the mock to avoid issues.

In my case, I use the user metadata within my app and my tests are failing.