### PR TITLE
Add support for userChanges

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -7,7 +7,8 @@ import 'mock_confirmation_result.dart';
 import 'mock_user_credential.dart';
 
 class MockFirebaseAuth implements FirebaseAuth {
-  final stateChangedStreamController = StreamController<User?>();
+  final authStateChangedStreamController = StreamController<User?>();
+  final userChangedStreamController = StreamController<User?>();
   final MockUser? _mockUser;
   User? _currentUser;
 
@@ -53,18 +54,23 @@ class MockFirebaseAuth implements FirebaseAuth {
   @override
   Future<void> signOut() async {
     _currentUser = null;
-    stateChangedStreamController.add(null);
+    authStateChangedStreamController.add(null);
+    userChangedStreamController.add(null);
   }
 
   Future<UserCredential> _fakeSignIn({bool isAnonymous = false}) {
     final userCredential = MockUserCredential(isAnonymous, mockUser: _mockUser);
     _currentUser = userCredential.user;
-    stateChangedStreamController.add(_currentUser);
+    authStateChangedStreamController.add(_currentUser);
+    userChangedStreamController.add(_currentUser);
     return Future.value(userCredential);
   }
 
   @override
-  Stream<User?> authStateChanges() => stateChangedStreamController.stream;
+  Stream<User?> authStateChanges() => authStateChangedStreamController.stream;
+
+  @override
+  Stream<User?> userChanges() => userChangedStreamController.stream;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -12,8 +12,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   final MockUser? _mockUser;
   User? _currentUser;
 
-  MockFirebaseAuth({signedIn = false, MockUser? mockUser})
-      : _mockUser = mockUser {
+  MockFirebaseAuth({signedIn = false, MockUser? mockUser}) : _mockUser = mockUser {
     if (signedIn) {
       signInWithCredential(null);
     }
@@ -43,8 +42,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   }
 
   @override
-  Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber,
-      [RecaptchaVerifier? verifier]) async {
+  Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber, [RecaptchaVerifier? verifier]) async {
     return MockConfirmationResult(onConfirm: () => _fakeSignIn());
   }
 
@@ -68,10 +66,9 @@ class MockFirebaseAuth implements FirebaseAuth {
     return Future.value(userCredential);
   }
 
-  @override
-  Stream<User> get onAuthStateChanged =>
-      authStateChanges().map((event) => event!);
+  Stream<User> get onAuthStateChanged => authStateChanges().map((event) => event!);
 
+  @override
   Stream<User?> authStateChanges() => stateChangedStreamController.stream;
 
   @override

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -28,16 +28,17 @@ void main() {
       final user = result.user!;
       expect(user, tUser);
       expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
       expect(user.isAnonymous, isFalse);
     });
 
     test('with email and password', () async {
       final auth = MockFirebaseAuth(mockUser: tUser);
-      final result = await auth.signInWithEmailAndPassword(
-          email: 'some email', password: 'some password');
+      final result = await auth.signInWithEmailAndPassword(email: 'some email', password: 'some password');
       final user = result.user;
       expect(user, tUser);
       expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
     });
 
     test('with token', () async {
@@ -46,16 +47,17 @@ void main() {
       final user = result.user;
       expect(user, tUser);
       expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
     });
 
     test('with phone number', () async {
       final auth = MockFirebaseAuth(mockUser: tUser);
-      final confirmationResult =
-          await auth.signInWithPhoneNumber('832 234 5678');
+      final confirmationResult = await auth.signInWithPhoneNumber('832 234 5678');
       final credentials = await confirmationResult.confirm('12345');
       final user = credentials.user;
       expect(user, tUser);
       expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
     });
 
     test('anonymously', () async {
@@ -64,6 +66,7 @@ void main() {
       final user = result.user!;
       expect(user.uid, isNotEmpty);
       expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
       expect(user.isAnonymous, isTrue);
     });
   });
@@ -89,6 +92,7 @@ void main() {
 
     expect(auth.currentUser, isNull);
     expect(auth.authStateChanges(), emitsInOrder([user, null]));
+    expect(auth.userChanges(), emitsInOrder([user, null]));
   });
 }
 


### PR DESCRIPTION
Adding support for userChanges method as per Issue #34.

I duplicated the work done on authStateChanges, userChanges basically mimics authStateChanges in our case (as we only push user changes through the stream).