### PR TITLE
Add export MockUserCredential

### DIFF
--- a/lib/firebase_auth_mocks.dart
+++ b/lib/firebase_auth_mocks.dart
@@ -5,3 +5,4 @@ library firebase_auth_mocks;
 
 export 'src/firebase_auth_mocks_base.dart';
 export 'src/mock_user.dart';
+export 'src/mock_user_credential.dart';


### PR DESCRIPTION
Hello. Thank you for creating a library for the mock fireAuth.

As I wrote the test code, I needed MockUserCredential.
However, it was not exported.
So I'd like to request the added code.
