### PR TITLE
Add providerData in MockUser

### DIFF
--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -9,6 +9,7 @@ class MockUser with EquatableMixin implements User {
   String? _displayName;
   final String? _phoneNumber;
   final String? _photoURL;
+  final List<UserInfo> _providerData;
   final String? _refreshToken;
   final UserMetadata? _metadata;
 
@@ -20,6 +21,7 @@ class MockUser with EquatableMixin implements User {
     String? displayName,
     String? phoneNumber,
     String? photoURL,
+    List<UserInfo>? providerData,
     String? refreshToken,
     UserMetadata? metadata,
   })  : _isAnonymous = isAnonymous,
@@ -29,6 +31,7 @@ class MockUser with EquatableMixin implements User {
         _displayName = displayName,
         _phoneNumber = phoneNumber,
         _photoURL = photoURL,
+        _providerData = providerData ?? [],
         _refreshToken = refreshToken,
         _metadata = metadata;
 
@@ -56,6 +59,9 @@ class MockUser with EquatableMixin implements User {
 
   @override
   String? get photoURL => _photoURL;
+
+  @override
+  List<UserInfo> get providerData => _providerData;
 
   @override
   String? get refreshToken => _refreshToken;


### PR DESCRIPTION
Since actual User has property providerData and I use it in my project
so I added it and default it to empty list

it fixed the problem because normally we check providerData if it empty we dont get data from it anyway 