### PR TITLE
Fire an event on startup even when signed out

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -12,9 +12,13 @@ class MockFirebaseAuth implements FirebaseAuth {
   final MockUser? _mockUser;
   User? _currentUser;
 
-  MockFirebaseAuth({signedIn = false, MockUser? mockUser}) : _mockUser = mockUser {
+  MockFirebaseAuth({signedIn = false, MockUser? mockUser})
+      : _mockUser = mockUser {
     if (signedIn) {
       signInWithCredential(null);
+    } else {
+      // Notify of null on startup.
+      signOut();
     }
   }
 
@@ -42,7 +46,8 @@ class MockFirebaseAuth implements FirebaseAuth {
   }
 
   @override
-  Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber, [RecaptchaVerifier? verifier]) async {
+  Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber,
+      [RecaptchaVerifier? verifier]) async {
     return MockConfirmationResult(onConfirm: () => _fakeSignIn());
   }
 
@@ -71,7 +76,8 @@ class MockFirebaseAuth implements FirebaseAuth {
     return Future.value(userCredential);
   }
 
-  Stream<User> get onAuthStateChanged => authStateChanges().map((event) => event!);
+  Stream<User> get onAuthStateChanged =>
+      authStateChanges().map((event) => event!);
 
   @override
   Stream<User?> authStateChanges() => stateChangedStreamController.stream;

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -19,6 +19,19 @@ void main() {
     expect(user, isNull);
   });
 
+  group('Emits an initial User? on startup.', () {
+    test('null if signed out', () async {
+      final auth = MockFirebaseAuth();
+      expect(auth.authStateChanges(), emits(null));
+      // expect(auth.userChanges(), emitsInOrder([isA<User>()]));
+    });
+    test('a user if signed in', () async {
+      final auth = MockFirebaseAuth(signedIn: true);
+      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
+    });
+  });
+
   group('Returns a mocked user user after sign in', () {
     test('with Credential', () async {
       final auth = MockFirebaseAuth(mockUser: tUser);
@@ -27,18 +40,19 @@ void main() {
       final result = await auth.signInWithCredential(credential);
       final user = result.user!;
       expect(user, tUser);
-      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
-      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([null, isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([null, isA<User>()]));
       expect(user.isAnonymous, isFalse);
     });
 
     test('with email and password', () async {
       final auth = MockFirebaseAuth(mockUser: tUser);
-      final result = await auth.signInWithEmailAndPassword(email: 'some email', password: 'some password');
+      final result = await auth.signInWithEmailAndPassword(
+          email: 'some email', password: 'some password');
       final user = result.user;
       expect(user, tUser);
-      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
-      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([null, isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([null, isA<User>()]));
     });
 
     test('with token', () async {
@@ -46,18 +60,19 @@ void main() {
       final result = await auth.signInWithCustomToken('some token');
       final user = result.user;
       expect(user, tUser);
-      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
-      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([null, isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([null, isA<User>()]));
     });
 
     test('with phone number', () async {
       final auth = MockFirebaseAuth(mockUser: tUser);
-      final confirmationResult = await auth.signInWithPhoneNumber('832 234 5678');
+      final confirmationResult =
+          await auth.signInWithPhoneNumber('832 234 5678');
       final credentials = await confirmationResult.confirm('12345');
       final user = credentials.user;
       expect(user, tUser);
-      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
-      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([null, isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([null, isA<User>()]));
     });
 
     test('anonymously', () async {
@@ -65,8 +80,8 @@ void main() {
       final result = await auth.signInAnonymously();
       final user = result.user!;
       expect(user.uid, isNotEmpty);
-      expect(auth.authStateChanges(), emitsInOrder([isA<User>()]));
-      expect(auth.userChanges(), emitsInOrder([isA<User>()]));
+      expect(auth.authStateChanges(), emitsInOrder([null, isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([null, isA<User>()]));
       expect(user.isAnonymous, isTrue);
     });
   });


### PR DESCRIPTION
Same as #30 but also fire on `userChanges` + unit tests.