### PR TITLE
Turn `userChanges` and `authStateChanges` into broadcast streams

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -8,12 +8,17 @@ import 'mock_user_credential.dart';
 
 class MockFirebaseAuth implements FirebaseAuth {
   final stateChangedStreamController = StreamController<User?>();
+  late Stream<User?> stateChangedStream;
   final userChangedStreamController = StreamController<User?>();
+  late Stream<User?> userChangedStream;
   final MockUser? _mockUser;
   User? _currentUser;
 
   MockFirebaseAuth({signedIn = false, MockUser? mockUser})
       : _mockUser = mockUser {
+    stateChangedStream =
+        stateChangedStreamController.stream.asBroadcastStream();
+    userChangedStream = userChangedStreamController.stream.asBroadcastStream();
     if (signedIn) {
       signInWithCredential(null);
     } else {
@@ -80,10 +85,10 @@ class MockFirebaseAuth implements FirebaseAuth {
       authStateChanges().map((event) => event!);
 
   @override
-  Stream<User?> authStateChanges() => stateChangedStreamController.stream;
+  Stream<User?> authStateChanges() => stateChangedStream;
 
   @override
-  Stream<User?> userChanges() => userChangedStreamController.stream;
+  Stream<User?> userChanges() => userChangedStream;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -124,6 +124,12 @@ void main() {
     await user!.updateDisplayName("New Bob");
     expect(user.displayName, "New Bob");
   });
+
+  test('Listening twice works', () async {
+    final auth = MockFirebaseAuth();
+    expect(await auth.userChanges().first, isNull);
+    expect(await auth.userChanges().first, isNull);
+  });
 }
 
 class FakeAuthCredential implements AuthCredential {


### PR DESCRIPTION
So that you can listen to them more than once.