### PR TITLE
Update firebase_auth_mocks_base.dart

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -14,7 +14,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   final MockUser? _mockUser;
   User? _currentUser;
 
-  MockFirebaseAuth({signedIn = false, MockUser? mockUser})
+  MockFirebaseAuth({bool signedIn = false, MockUser? mockUser})
       : _mockUser = mockUser {
     stateChangedStream =
         stateChangedStreamController.stream.asBroadcastStream();


### PR DESCRIPTION
Added typing for `signedIn` to avoid `dynamic`