### PR TITLE
Feature/MockFirebaseAuth allow exceptions to be thrown

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ main() {
     `signInAnonymously` and `createUserWithEmailAndPassword` signs in.
   - `signOut` method.
   - `currentUser`
+  - the ability to throw exceptions using `authExceptions`:
+  ```dart
+  final auth = MockFirebaseAuth(
+    authExceptions: AuthExceptions(
+      signInWithCredential: FirebaseAuthException(code: 'invalid-credential'),
+    ),
+  );
+  ```
 - `UserCredential` contains the provided `User` with the information of your choice.
 - `User` supports:
   - `updateDisplayName`

--- a/lib/firebase_auth_mocks.dart
+++ b/lib/firebase_auth_mocks.dart
@@ -3,5 +3,6 @@
 /// More dartdocs go here.
 library firebase_auth_mocks;
 
+export 'src/auth_exceptions.dart';
 export 'src/firebase_auth_mocks_base.dart';
 export 'src/mock_user.dart';

--- a/lib/src/auth_exceptions.dart
+++ b/lib/src/auth_exceptions.dart
@@ -1,0 +1,46 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+/// A class containing optional [FirebaseAuthException]s for methods in [FirebaseAuth]
+class AuthExceptions {
+  const AuthExceptions({
+    this.signInWithCredential,
+    this.signInWithEmailAndPassword,
+    this.createUserWithEmailAndPassword,
+    this.signInWithCustomToken,
+    this.signInAnonymously,
+    this.fetchSignInMethodsForEmail,
+  });
+
+  final FirebaseAuthException? signInWithCredential;
+  final FirebaseAuthException? signInWithEmailAndPassword;
+  final FirebaseAuthException? createUserWithEmailAndPassword;
+  final FirebaseAuthException? signInWithCustomToken;
+  final FirebaseAuthException? signInAnonymously;
+  final FirebaseAuthException? fetchSignInMethodsForEmail;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    return other is AuthExceptions &&
+        other.signInWithCredential == signInWithCredential &&
+        other.signInWithEmailAndPassword == signInWithEmailAndPassword &&
+        other.createUserWithEmailAndPassword ==
+            createUserWithEmailAndPassword &&
+        other.signInWithCustomToken == signInWithCustomToken &&
+        other.signInAnonymously == signInAnonymously &&
+        other.fetchSignInMethodsForEmail == fetchSignInMethodsForEmail;
+  }
+
+  @override
+  int get hashCode {
+    return signInWithCredential.hashCode ^
+        signInWithEmailAndPassword.hashCode ^
+        createUserWithEmailAndPassword.hashCode ^
+        signInWithCustomToken.hashCode ^
+        signInAnonymously.hashCode ^
+        fetchSignInMethodsForEmail.hashCode;
+  }
+}

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 
-import '../firebase_auth_mocks.dart';
+import 'auth_exceptions.dart';
 import 'mock_confirmation_result.dart';
+import 'mock_user.dart';
 import 'mock_user_credential.dart';
 
 class MockFirebaseAuth implements FirebaseAuth {
@@ -13,9 +14,14 @@ class MockFirebaseAuth implements FirebaseAuth {
   late Stream<User?> userChangedStream;
   MockUser? _mockUser;
   User? _currentUser;
+  final AuthExceptions? _authExceptions;
 
-  MockFirebaseAuth({bool signedIn = false, MockUser? mockUser})
-      : _mockUser = mockUser {
+  MockFirebaseAuth({
+    bool signedIn = false,
+    MockUser? mockUser,
+    AuthExceptions? authExceptions,
+  })  : _mockUser = mockUser,
+        _authExceptions = authExceptions {
     stateChangedStream =
         stateChangedStreamController.stream.asBroadcastStream();
     userChangedStream = userChangedStreamController.stream.asBroadcastStream();
@@ -34,6 +40,10 @@ class MockFirebaseAuth implements FirebaseAuth {
 
   @override
   Future<UserCredential> signInWithCredential(AuthCredential? credential) {
+    if (_authExceptions?.signInWithCredential != null) {
+      throw (_authExceptions!.signInWithCredential!);
+    }
+
     return _fakeSignIn();
   }
 
@@ -42,6 +52,10 @@ class MockFirebaseAuth implements FirebaseAuth {
     required String email,
     required String password,
   }) {
+    if (_authExceptions?.signInWithEmailAndPassword != null) {
+      throw (_authExceptions!.signInWithEmailAndPassword!);
+    }
+
     return _fakeSignIn();
   }
 
@@ -50,6 +64,10 @@ class MockFirebaseAuth implements FirebaseAuth {
     required String email,
     required String password,
   }) {
+    if (_authExceptions?.createUserWithEmailAndPassword != null) {
+      throw (_authExceptions!.createUserWithEmailAndPassword!);
+    }
+
     _mockUser = MockUser(
       uid: 'mock_uid',
       email: email,
@@ -60,6 +78,10 @@ class MockFirebaseAuth implements FirebaseAuth {
 
   @override
   Future<UserCredential> signInWithCustomToken(String token) async {
+    if (_authExceptions?.signInWithCustomToken != null) {
+      throw (_authExceptions!.signInWithCustomToken!);
+    }
+
     return _fakeSignIn();
   }
 
@@ -71,6 +93,10 @@ class MockFirebaseAuth implements FirebaseAuth {
 
   @override
   Future<UserCredential> signInAnonymously() {
+    if (_authExceptions?.signInAnonymously != null) {
+      throw (_authExceptions!.signInAnonymously!);
+    }
+
     return _fakeSignIn(isAnonymous: true);
   }
 
@@ -83,6 +109,10 @@ class MockFirebaseAuth implements FirebaseAuth {
 
   @override
   Future<List<String>> fetchSignInMethodsForEmail(String email) {
+    if (_authExceptions?.fetchSignInMethodsForEmail != null) {
+      throw (_authExceptions!.fetchSignInMethodsForEmail!);
+    }
+
     return Future.value([]);
   }
 

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -206,6 +206,12 @@ void main() {
     await auth.signOut();
     expect(await auth.userChanges().first, isNull);
   });
+
+  test('$AuthExceptions ensure equality', () {
+    final authExceptions1 = AuthExceptions();
+    final authExceptions2 = AuthExceptions();
+    expect(authExceptions1, authExceptions2);
+  });
 }
 
 class FakeAuthCredential implements AuthCredential {

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -125,6 +125,81 @@ void main() {
     expect(auth.userChanges(), emitsInOrder([user, null]));
   });
 
+  group('exceptions', () {
+    test('signInWithCredential', () async {
+      final auth = MockFirebaseAuth(
+        authExceptions: AuthExceptions(
+          signInWithCredential: FirebaseAuthException(code: 'bla'),
+        ),
+      );
+      expect(
+        () async => await auth.signInWithCredential(FakeAuthCredential()),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+    });
+
+    test('signInWithEmailAndPassword', () async {
+      final auth = MockFirebaseAuth(
+        authExceptions: AuthExceptions(
+          signInWithEmailAndPassword: FirebaseAuthException(code: 'bla'),
+        ),
+      );
+      expect(
+        () async =>
+            await auth.signInWithEmailAndPassword(email: '', password: ''),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+    });
+
+    test('createUserWithEmailAndPassword', () async {
+      final auth = MockFirebaseAuth(
+        authExceptions: AuthExceptions(
+          createUserWithEmailAndPassword: FirebaseAuthException(code: 'bla'),
+        ),
+      );
+      expect(
+        () async =>
+            await auth.createUserWithEmailAndPassword(email: '', password: ''),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+    });
+
+    test('signInWithCustomToken', () async {
+      final auth = MockFirebaseAuth(
+        authExceptions: AuthExceptions(
+          signInWithCustomToken: FirebaseAuthException(code: 'bla'),
+        ),
+      );
+      expect(
+        () async => await auth.signInWithCustomToken(''),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+    });
+
+    test('signInAnonymously', () async {
+      final auth = MockFirebaseAuth(
+        authExceptions: AuthExceptions(
+          signInAnonymously: FirebaseAuthException(code: 'bla'),
+        ),
+      );
+      expect(
+        () async => await auth.signInAnonymously(),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+    });
+
+    test('fetchSignInMethodsForEmail', () async {
+      final auth = MockFirebaseAuth(
+        authExceptions: AuthExceptions(
+            fetchSignInMethodsForEmail: FirebaseAuthException(code: 'bla')),
+      );
+      expect(
+        () async => await auth.fetchSignInMethodsForEmail(''),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+    });
+  });
+
   test('User.reload returns', () async {
     final auth = MockFirebaseAuth(signedIn: true);
     final user = auth.currentUser;


### PR DESCRIPTION
Allows methods `signInWithCredential` etc. to fake thrown exceptions. Looking at Firebase's source code, neither `signInWithPhoneNumber` nor `signOut` seem to throw, so I did not add a config for those methods.

Looking forward to feedback.