### PR TITLE
Add custom ID tokens

### DIFF
--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -13,6 +13,8 @@ class MockUser with EquatableMixin implements User {
   final List<UserInfo> _providerData;
   final String? _refreshToken;
   final UserMetadata? _metadata;
+  String? _idToken;
+  String? _refreshIdToken;
 
   MockUser({
     bool isAnonymous = false,
@@ -25,6 +27,8 @@ class MockUser with EquatableMixin implements User {
     List<UserInfo>? providerData,
     String? refreshToken,
     UserMetadata? metadata,
+    String customIdToken = 'fake_token',
+    String refreshIdToken = 'fake_refresh_token',
   })  : _isAnonymous = isAnonymous,
         _isEmailVerified = isEmailVerified,
         _uid = uid,
@@ -34,7 +38,9 @@ class MockUser with EquatableMixin implements User {
         _photoURL = photoURL,
         _providerData = providerData ?? [],
         _refreshToken = refreshToken,
-        _metadata = metadata;
+        _metadata = metadata,
+        _idToken = customIdToken,
+        _refreshIdToken = refreshIdToken;
 
   FirebaseAuthException? _exception;
 
@@ -74,7 +80,10 @@ class MockUser with EquatableMixin implements User {
 
   @override
   Future<String> getIdToken([bool forceRefresh = false]) async {
-    return Future.value('fake_token');
+    if (forceRefresh) {
+      _idToken = _refreshIdToken;
+    }
+    return Future.value(_idToken);
   }
 
   @override


### PR DESCRIPTION
Hi, I write custom claims on my API which I then verify on the app. I'm trying to test the specific code that handles this but I found it's missing on `firebase_auth_mocks`