### PR TITLE
Added getIdTokenResult support

### DIFF
--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -13,6 +13,7 @@ class MockUser with EquatableMixin implements User {
   final List<UserInfo> _providerData;
   final String? _refreshToken;
   final UserMetadata? _metadata;
+  final IdTokenResult? _idTokenResult;
 
   MockUser({
     bool isAnonymous = false,
@@ -25,6 +26,7 @@ class MockUser with EquatableMixin implements User {
     List<UserInfo>? providerData,
     String? refreshToken,
     UserMetadata? metadata,
+    IdTokenResult? idTokenResult,
   })  : _isAnonymous = isAnonymous,
         _isEmailVerified = isEmailVerified,
         _uid = uid,
@@ -34,7 +36,8 @@ class MockUser with EquatableMixin implements User {
         _photoURL = photoURL,
         _providerData = providerData ?? [],
         _refreshToken = refreshToken,
-        _metadata = metadata;
+        _metadata = metadata,
+        _idTokenResult = idTokenResult;
 
   FirebaseAuthException? _exception;
 
@@ -75,6 +78,11 @@ class MockUser with EquatableMixin implements User {
   @override
   Future<String> getIdToken([bool forceRefresh = false]) async {
     return Future.value('fake_token');
+  }
+
+  @override
+  Future<IdTokenResult> getIdTokenResult([bool forceRefresh = false]) {
+    return Future.value(_idTokenResult ?? IdTokenResult({}));
   }
 
   @override

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -5,14 +5,23 @@ import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:test/test.dart';
 
 final tUser = MockUser(
-  isAnonymous: false,
-  uid: 'T3STU1D',
-  email: 'bob@thebuilder.com',
-  displayName: 'Bob Builder',
-  phoneNumber: '0800 I CAN FIX IT',
-  photoURL: 'http://photos.url/bobbie.jpg',
-  refreshToken: 'some_long_token',
-);
+    isAnonymous: false,
+    uid: 'T3STU1D',
+    email: 'bob@thebuilder.com',
+    displayName: 'Bob Builder',
+    phoneNumber: '0800 I CAN FIX IT',
+    photoURL: 'http://photos.url/bobbie.jpg',
+    refreshToken: 'some_long_token',
+    idTokenResult: IdTokenResult({
+      'authTimestamp': DateTime.now().millisecondsSinceEpoch,
+      'claims': {'role': 'admin'},
+      'token': 'some_long_token',
+      'expirationTime':
+          DateTime.now().add(Duration(days: 1)).millisecondsSinceEpoch,
+      'issuedAtTimestamp':
+          DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch,
+      'signInProvider': 'phone',
+    }));
 
 void main() {
   test('Returns no user if not signed in', () async {


### PR DESCRIPTION
**What this PR contains**
Added support for mocking getIdTokenResult.  Most useful for custom claims, which can be used for role-based access control.

- Adds ```IdTokenResult? _idTokenResult``` private property in MockUser
- Adds ```IdTokenResult? idTokenResult``` optional property for MockUser constructor
- Overrides ```dart Future<IdTokenResult> getIdTokenResult([bool forceRefresh = false])``` in MockUser to return the the _idTokenResult property as a Future value
- Adds idTokenResult mock data to the test user in firebase_auth_mocks_test.dart
