### PR TITLE
MockUser adds the ability to create a JWT

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -140,7 +140,8 @@ class MockFirebaseAuth implements FirebaseAuth {
 
   @override
   Future<void> verifyPhoneNumber({
-    required String phoneNumber,
+    String? phoneNumber,
+    PhoneMultiFactorInfo? multiFactorInfo,
     required PhoneVerificationCompleted verificationCompleted,
     required PhoneVerificationFailed verificationFailed,
     required PhoneCodeSent codeSent,
@@ -148,6 +149,7 @@ class MockFirebaseAuth implements FirebaseAuth {
     @visibleForTesting String? autoRetrievedSmsCodeForTesting,
     Duration timeout = const Duration(seconds: 30),
     int? forceResendingToken,
+    MultiFactorSession? multiFactorSession,
   }) async {
     codeSent('verification-id', 0);
   }

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -1,4 +1,5 @@
 import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:uuid/uuid.dart';
 import 'package:equatable/equatable.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/src/mock_user_credential.dart';
@@ -18,7 +19,7 @@ class MockUser with EquatableMixin implements User {
   MockUser({
     bool isAnonymous = false,
     bool isEmailVerified = true,
-    String uid = 'some_random_id',
+    String? uid,
     String? email,
     String? displayName,
     String? phoneNumber,
@@ -28,7 +29,7 @@ class MockUser with EquatableMixin implements User {
     UserMetadata? metadata,
   })  : _isAnonymous = isAnonymous,
         _isEmailVerified = isEmailVerified,
-        _uid = uid,
+        _uid = uid ?? const Uuid().v4(),
         _email = email,
         _displayName = displayName,
         _phoneNumber = phoneNumber,
@@ -52,7 +53,7 @@ class MockUser with EquatableMixin implements User {
   String get uid => _uid;
 
   @override
-  String? get email => _email;
+  String? get email => _email ?? '_test_$uid@test.test';
 
   @override
   String? get displayName => _displayName;

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -56,7 +56,7 @@ class MockUser with EquatableMixin implements User {
   String? get email => _email ?? '_test_$uid@example.test';
 
   @override
-  String? get displayName => _displayName;
+  String? get displayName => _displayName ?? 'fake_name';
 
   set displayName(String? value) {
     _displayName = value;
@@ -66,7 +66,7 @@ class MockUser with EquatableMixin implements User {
   String? get phoneNumber => _phoneNumber;
 
   @override
-  String? get photoURL => _photoURL;
+  String? get photoURL => _photoURL ?? 'https://i.stack.imgur.com/34AD2.jpg';
 
   @override
   List<UserInfo> get providerData => _providerData;
@@ -77,8 +77,8 @@ class MockUser with EquatableMixin implements User {
   @override
   Future<String> getIdToken([bool forceRefresh = false]) {
     var payload = {
-      'name': displayName ?? 'fake_name',
-      'picture': photoURL ?? 'https://i.stack.imgur.com/34AD2.jpg',
+      'name': displayName,
+      'picture': photoURL,
       'iss': 'fake_iss',
       'aud': 'fake_aud',
       'auth_time': 1655946582,

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -1,3 +1,4 @@
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:equatable/equatable.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/src/mock_user_credential.dart';
@@ -73,8 +74,36 @@ class MockUser with EquatableMixin implements User {
   String? get refreshToken => _refreshToken;
 
   @override
-  Future<String> getIdToken([bool forceRefresh = false]) async {
-    return Future.value('fake_token');
+  Future<String> getIdToken([bool forceRefresh = false]) {
+    var payload = {
+      'name': displayName ?? 'fake_name',
+      'picture': photoURL ?? 'https://i.stack.imgur.com/34AD2.jpg',
+      'iss': 'fake_iss',
+      'aud': 'fake_aud',
+      'auth_time': 1655946582,
+      'user_id': uid,
+      'sub': uid,
+      'iat': 1656302136,
+      'exp': 1656305736,
+      'email': email,
+      'email_verified': emailVerified,
+      'firebase': {
+        'identities': {
+          'google.com': ['fake_identity'],
+          'email': [email]
+        },
+        'sign_in_provider': 'google.com'
+      }
+    };
+    // Create a json web token
+    final jwt = JWT(
+      payload,
+      issuer: 'https://github.com/jonasroussel/dart_jsonwebtoken',
+    );
+
+    // Sign it (default with HS256 algorithm)
+    var token = jwt.sign(SecretKey('secret passphrase'));
+    return Future.value(token);
   }
 
   @override

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -53,7 +53,7 @@ class MockUser with EquatableMixin implements User {
   String get uid => _uid;
 
   @override
-  String? get email => _email ?? '_test_$uid@test.test';
+  String? get email => _email ?? '_test_$uid@example.test';
 
   @override
   String? get displayName => _displayName;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   firebase_auth: ^3.0.0
   meta: ^1.3.0
   equatable: ^2.0.0
+  dart_jsonwebtoken: ^2.4.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   meta: ^1.3.0
   equatable: ^2.0.0
   dart_jsonwebtoken: ^2.4.1
+  uuid: ^3.0.6
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,3 +21,4 @@ dev_dependencies:
     sdk: flutter
   pedantic: ^1.11.0
   test: ^1.0.0
+  jwt_decoder: ^2.0.1

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -358,6 +358,18 @@ void main() {
     expect(decodedToken['email_verified'], tUser.emailVerified);
   });
 
+  test('Id token contains user data when using default value', () async {
+    final user = MockUser();
+    final idToken = await user.getIdToken();
+    final decodedToken = JwtDecoder.decode(idToken);
+    expect(decodedToken['name'], user.displayName);
+    expect(decodedToken['picture'], user.photoURL);
+    expect(decodedToken['user_id'], user.uid);
+    expect(decodedToken['sub'], user.uid);
+    expect(decodedToken['email'], user.email);
+    expect(decodedToken['email_verified'], user.emailVerified);
+  });
+
   test('getIdToken still works when using the default value', () async {
     final idToken = await MockUser().getIdToken();
     final decodedToken = JwtDecoder.decode(idToken);

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:test/test.dart';
 
 final tUser = MockUser(
@@ -305,6 +307,49 @@ void main() {
     final authExceptions1 = AuthExceptions();
     final authExceptions2 = AuthExceptions();
     expect(authExceptions1, authExceptions2);
+  });
+
+  test('Id token contains user data', () async {
+    final idToken = await tUser.getIdToken();
+    final decodedToken = JwtDecoder.decode(idToken);
+    expect(decodedToken['name'], tUser.displayName);
+    expect(decodedToken['picture'], tUser.photoURL);
+    expect(decodedToken['user_id'], tUser.uid);
+    expect(decodedToken['sub'], tUser.uid);
+    expect(decodedToken['email'], tUser.email);
+    expect(decodedToken['email_verified'], tUser.emailVerified);
+  });
+
+  test('getIdToken still works when using the default value', () async {
+    final idToken = await MockUser().getIdToken();
+    final decodedToken = JwtDecoder.decode(idToken);
+    expect(decodedToken['name'] != null, true);
+    expect(decodedToken['picture'] != null, true);
+    expect(decodedToken['user_id'] != null, true);
+    expect(decodedToken['sub'] != null, true);
+    expect(decodedToken['email'] != null, true);
+    expect(decodedToken['email_verified'] != null, true);
+  });
+
+  test('Each decoded token\'s user_id should not change', () async {
+    final user = MockUser();
+    final idToken1 = await user.getIdToken();
+    final decodedToken1 = JwtDecoder.decode(idToken1);
+    final idToken2 = await user.getIdToken();
+    final decodedToken2 = JwtDecoder.decode(idToken2);
+    expect(decodedToken1['user_id'], decodedToken2['user_id']);
+  });
+
+  test('Each edecoded token\'s user_id should unique', () async {
+    final user1 = MockUser();
+    final user2 = MockUser();
+    final idToken1 = await user1.getIdToken();
+    final decodedToken1 = JwtDecoder.decode(idToken1);
+    final idToken2 = await user2.getIdToken();
+    final decodedToken2 = JwtDecoder.decode(idToken2);
+    expect(decodedToken1['user_id'] is String, true);
+    expect(decodedToken2['user_id'] is String, true);
+    expect(decodedToken1['user_id'] != decodedToken2['user_id'], true);
   });
 }
 

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
It will make the MockUser's getIdToken method able to generate a JWT.

When doing an integration test, I think creating a JWT is better than returning a fixed string because the server can use the JWT decoder to retrieve uid from the JWT. With this unique uid, we can easily do some CRUD during the integration test.