### PR TITLE
Implement sendPasswordResetEmail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ doc/api/
 # VSCode settings
 .vscode
 
+# Android Studio settings
+.idea
+
 # FVM local path
 .fvm

--- a/lib/src/auth_exceptions.dart
+++ b/lib/src/auth_exceptions.dart
@@ -9,6 +9,7 @@ class AuthExceptions {
     this.signInWithCustomToken,
     this.signInAnonymously,
     this.fetchSignInMethodsForEmail,
+    this.sendPasswordResetEmail,
   });
 
   final FirebaseAuthException? signInWithCredential;
@@ -17,6 +18,7 @@ class AuthExceptions {
   final FirebaseAuthException? signInWithCustomToken;
   final FirebaseAuthException? signInAnonymously;
   final FirebaseAuthException? fetchSignInMethodsForEmail;
+  final FirebaseAuthException? sendPasswordResetEmail;
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/auth_exceptions.dart
+++ b/lib/src/auth_exceptions.dart
@@ -1,7 +1,8 @@
+import 'package:equatable/equatable.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 /// A class containing optional [FirebaseAuthException]s for methods in [FirebaseAuth]
-class AuthExceptions {
+class AuthExceptions extends Equatable {
   const AuthExceptions({
     this.signInWithCredential,
     this.signInWithEmailAndPassword,
@@ -21,28 +22,13 @@ class AuthExceptions {
   final FirebaseAuthException? sendPasswordResetEmail;
 
   @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-
-    return other is AuthExceptions &&
-        other.signInWithCredential == signInWithCredential &&
-        other.signInWithEmailAndPassword == signInWithEmailAndPassword &&
-        other.createUserWithEmailAndPassword ==
-            createUserWithEmailAndPassword &&
-        other.signInWithCustomToken == signInWithCustomToken &&
-        other.signInAnonymously == signInAnonymously &&
-        other.fetchSignInMethodsForEmail == fetchSignInMethodsForEmail;
-  }
-
-  @override
-  int get hashCode {
-    return signInWithCredential.hashCode ^
-        signInWithEmailAndPassword.hashCode ^
-        createUserWithEmailAndPassword.hashCode ^
-        signInWithCustomToken.hashCode ^
-        signInAnonymously.hashCode ^
-        fetchSignInMethodsForEmail.hashCode;
-  }
+  List<Object?> get props => [
+        signInWithCredential,
+        signInWithEmailAndPassword,
+        createUserWithEmailAndPassword,
+        signInWithCustomToken,
+        signInAnonymously,
+        fetchSignInMethodsForEmail,
+        sendPasswordResetEmail,
+      ];
 }

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -153,5 +153,17 @@ class MockFirebaseAuth implements FirebaseAuth {
   }
 
   @override
+  Future<void> sendPasswordResetEmail({
+    required String email,
+    ActionCodeSettings? actionCodeSettings,
+  }) {
+    if(_authExceptions?.sendPasswordResetEmail != null){
+      throw _authExceptions!.sendPasswordResetEmail!;
+    }
+
+    return Future.value();
+  }
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -144,6 +144,15 @@ void main() {
     expect(auth.userChanges(), emitsInOrder([user, null]));
   });
 
+  test('sendPasswordResetEmail works', () async {
+    final auth = MockFirebaseAuth();
+
+    expect(
+      () async => await auth.sendPasswordResetEmail(email: ''),
+      returnsNormally,
+    );
+  });
+
   group('exceptions', () {
     test('signInWithCredential', () async {
       final auth = MockFirebaseAuth(
@@ -214,6 +223,19 @@ void main() {
       );
       expect(
         () async => await auth.fetchSignInMethodsForEmail(''),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+    });
+
+    test('sendPasswordResetEmail', () async {
+      final auth = MockFirebaseAuth(
+        authExceptions: AuthExceptions(
+          sendPasswordResetEmail: FirebaseAuthException(code: 'invalid-email'),
+        ),
+      );
+
+      expect(
+        () async => await auth.sendPasswordResetEmail(email: ''),
         throwsA(isA<FirebaseAuthException>()),
       );
     });


### PR DESCRIPTION
**Summary**
* implemented ```sendPasswordResetEmail``` in ```MockFirebaseAuth```
* added tests for the new method
* changed ```AuthExceptions``` to make use of ```Equatable```, since it's already added as a dependency

I have also added ```.idea``` in ```.gitignore``` for future Android Studio users.