### PR TITLE
Implement sendSignInLinkToEmail, confirmPasswordReset and verifyPasswordResetCode

### DIFF
--- a/lib/src/auth_exceptions.dart
+++ b/lib/src/auth_exceptions.dart
@@ -11,6 +11,9 @@ class AuthExceptions extends Equatable {
     this.signInAnonymously,
     this.fetchSignInMethodsForEmail,
     this.sendPasswordResetEmail,
+    this.sendSignInLinkToEmail,
+    this.confirmPasswordReset,
+    this.verifyPasswordResetCode,
   });
 
   final FirebaseAuthException? signInWithCredential;
@@ -20,6 +23,9 @@ class AuthExceptions extends Equatable {
   final FirebaseAuthException? signInAnonymously;
   final FirebaseAuthException? fetchSignInMethodsForEmail;
   final FirebaseAuthException? sendPasswordResetEmail;
+  final FirebaseAuthException? sendSignInLinkToEmail;
+  final FirebaseAuthException? confirmPasswordReset;
+  final FirebaseAuthException? verifyPasswordResetCode;
 
   @override
   List<Object?> get props => [
@@ -30,5 +36,8 @@ class AuthExceptions extends Equatable {
         signInAnonymously,
         fetchSignInMethodsForEmail,
         sendPasswordResetEmail,
+        sendSignInLinkToEmail,
+        confirmPasswordReset,
+        verifyPasswordResetCode,
       ];
 }

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -170,5 +170,44 @@ class MockFirebaseAuth implements FirebaseAuth {
   }
 
   @override
+  Future<void> sendSignInLinkToEmail({
+    required String email,
+    required ActionCodeSettings actionCodeSettings,
+  }) {
+    if (actionCodeSettings.handleCodeInApp != true) {
+      throw ArgumentError(
+        'The [handleCodeInApp] value of [ActionCodeSettings] must be `true`.',
+      );
+    }
+
+    if (_authExceptions?.sendSignInLinkToEmail != null) {
+      throw _authExceptions!.sendSignInLinkToEmail!;
+    }
+
+    return Future.value();
+  }
+
+  @override
+  Future<void> confirmPasswordReset({
+    required String code,
+    required String newPassword,
+  }) {
+    if (_authExceptions?.confirmPasswordReset != null) {
+      throw _authExceptions!.confirmPasswordReset!;
+    }
+
+    return Future.value();
+  }
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) {
+    if (_authExceptions?.verifyPasswordResetCode != null) {
+      throw _authExceptions!.verifyPasswordResetCode!;
+    }
+
+    return Future.value(_mockUser?.email ?? 'email@example.com');
+  }
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }


### PR DESCRIPTION
**Summary**
* implemented ```sendSignInLinkToEmail```, ```confirmPasswordReset``` and ```verifyPasswordResetCode``` in ```MockFirebaseAuth```
* added tests for new methods

```sendSignInLinkToEmail``` throws ```ArgumentError``` if ```ActionCodeSettings.handleCodeInApp``` is not ```true``` to ensure that the behaviour is consistent with original method.

I was not sure what to return in ```verifyPasswordResetCode```, as returning empty string did not seem correct. Instead it returns ```MockUser.email``` or, if that is null, a hardcoded email.