### PR TITLE
MockUser.email do not return hardcoded value

### DIFF
--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -59,7 +59,7 @@ class MockUser with EquatableMixin implements User {
   String get uid => _uid;
 
   @override
-  String? get email => _email ?? '_test_$uid@example.test';
+  String? get email => _email;
 
   @override
   String? get displayName => _displayName ?? 'fake_name';

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -496,17 +496,6 @@ void main() {
     expect(decodedToken['email_verified'], user.emailVerified);
   });
 
-  test('getIdToken still works when using the default value', () async {
-    final idToken = await MockUser().getIdToken();
-    final decodedToken = JwtDecoder.decode(idToken);
-    expect(decodedToken['name'], isNotNull);
-    expect(decodedToken['picture'], isNotNull);
-    expect(decodedToken['user_id'], isNotNull);
-    expect(decodedToken['sub'], isNotNull);
-    expect(decodedToken['email'], isNotNull);
-    expect(decodedToken['email_verified'], isNotNull);
-  });
-
   test('Each decoded token\'s user_id should not change', () async {
     final user = MockUser();
     final idToken1 = await user.getIdToken();
@@ -555,6 +544,16 @@ void main() {
     expect(decodedToken['auth_time'],
         customAuthTime.millisecondsSinceEpoch ~/ 1000);
     expect(decodedToken['exp'], customExp.millisecondsSinceEpoch ~/ 1000);
+  });
+
+  group('MockUser', () {
+    test('when default constructor, expect defaults', () {
+      final user = MockUser();
+      expect(user.isAnonymous, isFalse);
+      expect(user.emailVerified, isTrue);
+      expect(user.uid, isNotNull);
+      expect(user.email, isNull);
+    });
   });
 }
 


### PR DESCRIPTION
In #61, `MockUser` was updated to return a hardcoded value for `email` getter when one is not supplied to constructor. This is non-optional as `email` can actually be null for a [`User`](https://pub.dev/documentation/firebase_auth/latest/firebase_auth/User-class.html) in the case that anonymous sign in is used. This PR reverts this change from #61. The test "getIdToken still works when using the default value" was removed as this does not seem to add value over existing "Id token contains user data when using default value".

Potentially `displayName`, `photoUrl` etc. could all also be reverted to `String?` from hardcoded values as these are all null for anonymous users. Let me know if I should open an issue/relevant PR.