### PR TITLE
Added support fetchSignInMethodsForEmail()

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -14,6 +14,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   final userChangedStreamController = StreamController<User?>();
   late Stream<User?> userChangedStream;
   MockUser? _mockUser;
+  final Map<String, List<String>> _signInMethodsForEmail;
   User? _currentUser;
   final AuthExceptions? _authExceptions;
 
@@ -21,8 +22,10 @@ class MockFirebaseAuth implements FirebaseAuth {
     bool signedIn = false,
     MockUser? mockUser,
     AuthExceptions? authExceptions,
+    Map<String, List<String>>? signInMethodsForEmail,
   })  : _mockUser = mockUser,
-        _authExceptions = authExceptions {
+        _authExceptions = authExceptions,
+        _signInMethodsForEmail = signInMethodsForEmail ?? {} {
     stateChangedStream =
         stateChangedStreamController.stream.asBroadcastStream();
     userChangedStream = userChangedStreamController.stream.asBroadcastStream();
@@ -114,7 +117,7 @@ class MockFirebaseAuth implements FirebaseAuth {
       throw (_authExceptions!.fetchSignInMethodsForEmail!);
     }
 
-    return Future.value([]);
+    return Future.value(_signInMethodsForEmail[email] ?? []);
   }
 
   Future<UserCredential> _fakeSignIn({bool isAnonymous = false}) {

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -571,6 +571,16 @@ void main() {
     expect(decodedToken['exp'], customExp.millisecondsSinceEpoch ~/ 1000);
   });
 
+  test('Set up fetchSignInMethodsForEmail results', () async {
+    final auth = MockFirebaseAuth(
+      signInMethodsForEmail: {
+        'test@example.com': ['password']
+      },
+    );
+    expect(await auth.fetchSignInMethodsForEmail('test@example.com'),
+        equals(['password']));
+  });
+
   group('MockUser', () {
     test('when default constructor, expect defaults', () {
       final user = MockUser();


### PR DESCRIPTION
In order to control the results of `fetchSignInMethodsForEmail()`, I've added an extra optional constructor parameter to `MockFirebaseAuth`. This allows for setting up situations where a user might need to link credentials (using `User.linkWithCredential()`).