### PR TITLE
Added support for User.linkWithCredential()

### DIFF
--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -193,6 +193,13 @@ class MockUser with EquatableMixin implements User {
     return Future.value();
   }
 
+  @override
+  Future<UserCredential> linkWithCredential(AuthCredential credential) async {
+    _maybeThrowException();
+
+    return Future.value(MockUserCredential(false, mockUser: this));
+  }
+
   void _maybeThrowException() {
     if (_exception != null) {
       final exceptionCopy = _exception!;

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -262,6 +262,14 @@ void main() {
     },
   );
 
+  test('should link credentials', () async {
+    final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
+    final user = auth.currentUser;
+    final credential =
+        AuthCredential(providerId: 'providerId', signInMethod: 'signInMethod');
+    expect(user?.linkWithCredential(credential), completes);
+  });
+
   group('exceptions', () {
     test('signInWithCredential', () async {
       final auth = MockFirebaseAuth(
@@ -480,6 +488,18 @@ void main() {
     final user = auth.currentUser;
     expect(
       () async => await user?.sendEmailVerification(),
+      throwsA(isA<FirebaseAuthException>()),
+    );
+  });
+
+  test('User.linkWithCredential can throw exception', () async {
+    final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
+    final user = auth.currentUser;
+    final credential =
+        AuthCredential(providerId: 'providerId', signInMethod: 'signInMethod');
+    tUser.exception = FirebaseAuthException(code: 'verification-failure');
+    expect(
+      () async => await user?.linkWithCredential(credential),
       throwsA(isA<FirebaseAuthException>()),
     );
   });


### PR DESCRIPTION
In order to test `User.linkWithCredential()`, this method had to be added to the `MockUser` class.