### PR TITLE
Small fix to support anonymous firebase auth user

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -30,7 +30,11 @@ class MockFirebaseAuth implements FirebaseAuth {
         stateChangedStreamController.stream.asBroadcastStream();
     userChangedStream = userChangedStreamController.stream.asBroadcastStream();
     if (signedIn) {
-      signInWithCredential(null);
+      if (mockUser?.isAnonymous ?? false) {
+        signInAnonymously();
+      } else {
+        signInWithCredential(null);
+      }
     } else {
       // Notify of null on startup.
       signOut();

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -68,7 +68,7 @@ class MockUser with EquatableMixin implements User {
   String? get email => _email;
 
   @override
-  String? get displayName => _displayName ?? 'fake_name';
+  String? get displayName => _displayName;
 
   set displayName(String? value) {
     _displayName = value;

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -139,6 +139,13 @@ void main() {
     expect(user, tUser);
   });
 
+  test('Returns a mocked anonymous user if already signed in', () {
+    var anonymousUser = MockUser(isAnonymous: true, uid: 'T3STU1D');
+    final auth = MockFirebaseAuth(signedIn: true, mockUser: anonymousUser);
+    final user = auth.currentUser;
+    expect(user, anonymousUser);
+  });
+
   test('Returns a hardcoded user token', () async {
     final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
     final user = auth.currentUser!;


### PR DESCRIPTION
When trying to test with an already authenticated anonymous user, the assert in the `MockUserCredential` constructor would fail. This PR is an attempt to fix this.

An alternative solution would be:

``` dart
  Future<UserCredential> _fakeSignIn({bool isAnonymous = false}) {
    // final userCredential = MockUserCredential(isAnonymous, mockUser: _mockUser);
    final userCredential = MockUserCredential(_mockUser?.isAnonymous ?? isAnonymous, mockUser: _mockUser);
    ...
  }
```
But I guess the one in the commit is better...