### PR TITLE
use mock_exceptions for signInWithCredential

### DIFF
--- a/lib/src/auth_exceptions.dart
+++ b/lib/src/auth_exceptions.dart
@@ -4,7 +4,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 /// A class containing optional [FirebaseAuthException]s for methods in [FirebaseAuth]
 class AuthExceptions extends Equatable {
   const AuthExceptions({
-    this.signInWithCredential,
     this.signInWithEmailAndPassword,
     this.createUserWithEmailAndPassword,
     this.signInWithCustomToken,
@@ -18,7 +17,6 @@ class AuthExceptions extends Equatable {
     this.signInWithPopup,
   });
 
-  final FirebaseAuthException? signInWithCredential;
   final FirebaseAuthException? signInWithEmailAndPassword;
   final FirebaseAuthException? createUserWithEmailAndPassword;
   final FirebaseAuthException? signInWithCustomToken;
@@ -33,7 +31,6 @@ class AuthExceptions extends Equatable {
 
   @override
   List<Object?> get props => [
-        signInWithCredential,
         signInWithEmailAndPassword,
         createUserWithEmailAndPassword,
         signInWithCustomToken,

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:meta/meta.dart';
+import 'package:mock_exceptions/mock_exceptions.dart';
 
 import 'auth_exceptions.dart';
 import 'mock_confirmation_result.dart';
@@ -64,9 +65,8 @@ class MockFirebaseAuth implements FirebaseAuth {
 
   @override
   Future<UserCredential> signInWithCredential(AuthCredential? credential) {
-    if (_authExceptions?.signInWithCredential != null) {
-      throw (_authExceptions!.signInWithCredential!);
-    }
+    maybeThrowException(
+        this, Invocation.method(#signInWithCredential, [credential]));
 
     return _fakeSignIn();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   dart_jsonwebtoken: ^2.4.1
   uuid: ^3.0.6
   firebase_auth_platform_interface: ^6.11.7
+  mock_exceptions: ^0.8.2
 
 dev_dependencies:
   flutter_test:

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
+import 'package:mock_exceptions/mock_exceptions.dart';
 import 'package:test/test.dart';
 
 final userIdTokenResult = IdTokenResult({
@@ -323,11 +324,10 @@ void main() {
     });
 
     test('signInWithCredential', () async {
-      final auth = MockFirebaseAuth(
-        authExceptions: AuthExceptions(
-          signInWithCredential: FirebaseAuthException(code: 'bla'),
-        ),
-      );
+      final auth = MockFirebaseAuth();
+      whenCalling(Invocation.method(#signInWithCredential, [anything]))
+          .on(auth)
+          .thenThrow(FirebaseAuthException(code: 'bla'));
       expect(
         () async => await auth.signInWithCredential(FakeAuthCredential()),
         throwsA(isA<FirebaseAuthException>()),


### PR DESCRIPTION
Instead of:
```dart
final auth = MockFirebaseAuth(
  authExceptions: AuthExceptions(
    signInWithCredential: FirebaseAuthException(code: 'veronica'),
  ),
);
```

Use the pattern:
```dart
whenCalling(Invocation.method(#signInWithCredential, [anything]))
  .on(auth)
  .thenThrow(FirebaseAuthException(code: 'bla'));
```