### PR TITLE
Randomize test order

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
-      - run: flutter test test-randomize-ordering-seed 1
+      - run: flutter test --test-randomize-ordering-seed 1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
-      - run: flutter test
+      - run: flutter test test-randomize-ordering-seed 1

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -577,47 +577,31 @@ void main() {
     );
   });
 
-  // Temp variable to hold tUser before provider is linked
-  final _unlinkedTUser = tUser;
-
-  test('User.linkWithProvider works if not already linked', () async {
+  test('User.linkWithProvider and unlink', () async {
     final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
     final user = auth.currentUser;
     final provider = TwitterAuthProvider();
+    // linkWithProvider works if not already linked.
     final cred = await user!.linkWithProvider(provider);
     expect(cred, isNotNull);
     expect(
       user.providerData.any((info) => info.providerId == 'twitter.com'),
       true,
     );
-  });
-
-  test('User.linkWithProvider throws Exception if already linked', () async {
-    // tUser is still linked to twitter.com from previous test
-    final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
-    final user = auth.currentUser;
-    final provider = TwitterAuthProvider();
+    // tUser is still linked to twitter.com from previous test.
+    // linkWithProvider throws Exception if already linked.
     expect(
-      () async => await user!.linkWithProvider(provider),
+      () async => await user.linkWithProvider(provider),
       throwsA(isA<FirebaseAuthException>()),
     );
-  });
 
-  test('User.unlink succeeds', () async {
-    final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
-    final user = auth.currentUser;
-    final provider = TwitterAuthProvider();
-    final newUser = await user!.unlink(provider.providerId);
-    expect(newUser, _unlinkedTUser);
-  });
+    // unlink succeeds.
+    final newUser = await user.unlink(provider.providerId);
+    expect(newUser.providerData, isEmpty);
 
-  // tUser should now be unlinked
-  test('User.unlink throws Exception if no provider is linked', () async {
-    final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
-    final user = auth.currentUser;
-    final provider = TwitterAuthProvider();
+    // unlink throws Exception if no provider is linked.
     expect(
-      () async => await user!.unlink(provider.providerId),
+      () async => await user.unlink(provider.providerId),
       throwsA(isA<FirebaseAuthException>()),
     );
   });


### PR DESCRIPTION
Introducing tests with side effects which rely on the test order such as in #91 makes it harder to maintain. This PR enables random test orders so that we don't accidentally introduce such tests.