### PR TITLE
Add option to skip email verification when creating a user

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -134,7 +134,7 @@ class MockFirebaseAuth implements FirebaseAuth {
         UserInfo({
           'email': email,
           'uid': id,
-          'providerId': 'password'
+          'providerId': 'password',
         }),
       ],
     );

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -20,6 +20,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   MockUser? _mockUser;
   final Map<String, List<String>> _signInMethodsForEmail;
   User? _currentUser;
+  final bool _verifyEmailAutomatically;
 
   /// Pass this to FakeFirestore's constructor so it can apply security rules
   /// according to the signed in user. It builds the `auth` Map defined at
@@ -39,7 +40,9 @@ class MockFirebaseAuth implements FirebaseAuth {
     bool signedIn = false,
     MockUser? mockUser,
     Map<String, List<String>>? signInMethodsForEmail,
+    bool verifyEmailAutomatically = true
   })  : _mockUser = mockUser,
+        _verifyEmailAutomatically = verifyEmailAutomatically,
         _signInMethodsForEmail = signInMethodsForEmail ?? {},
         app = MockFirebaseApp() {
     stateChangedStream =
@@ -125,12 +128,13 @@ class MockFirebaseAuth implements FirebaseAuth {
     _mockUser = MockUser(
       uid: id,
       email: email,
+      isEmailVerified: _verifyEmailAutomatically,
       displayName: 'Mock User',
       providerData: [
         UserInfo({
           'email': email,
           'uid': id,
-          'providerId': 'password',
+          'providerId': 'password'
         }),
       ],
     );

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -55,7 +55,7 @@ void main() {
   });
 
   group('Returns a mocked user user after sign up', () {
-    test('with email and password', () async {
+    test('with verified email and password', () async {
       final email = 'some@email.com';
       final password = 'some!password';
       final auth = MockFirebaseAuth();
@@ -72,7 +72,29 @@ void main() {
       expect(auth.authStateChanges(), emitsInOrder([null, isA<User>()]));
       expect(auth.userChanges(), emitsInOrder([null, isA<User>()]));
       expect(user.isAnonymous, isFalse);
+      expect(user.emailVerified, isTrue);
     });
+
+    test('with unverified email and password', () async {
+      final email = 'some@email.com';
+      final password = 'some!password';
+      final auth = MockFirebaseAuth(verifyEmailAutomatically: false);
+      final result = await auth.createUserWithEmailAndPassword(
+          email: email, password: password);
+      final user = result.user!;
+      expect(user.email, email);
+      final providerData = user.providerData;
+      expect(providerData.length, 1);
+      expect(providerData.first.providerId, 'password');
+      expect(providerData.first.email, 'some@email.com');
+      expect(providerData.first.uid, user.uid);
+
+      expect(auth.authStateChanges(), emitsInOrder([null, isA<User>()]));
+      expect(auth.userChanges(), emitsInOrder([null, isA<User>()]));
+      expect(user.isAnonymous, isFalse);
+      expect(user.emailVerified, isFalse);
+    });
+
   });
 
   group('Returns a mocked user after sign in', () {

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -55,7 +55,7 @@ void main() {
   });
 
   group('Returns a mocked user user after sign up', () {
-    test('with verified email and password', () async {
+    test('with email and password', () async {
       final email = 'some@email.com';
       final password = 'some!password';
       final auth = MockFirebaseAuth();
@@ -75,7 +75,7 @@ void main() {
       expect(user.emailVerified, isTrue);
     });
 
-    test('with unverified email and password', () async {
+    test('with email and password without email verification by default', () async {
       final email = 'some@email.com';
       final password = 'some!password';
       final auth = MockFirebaseAuth(verifyEmailAutomatically: false);


### PR DESCRIPTION
By default, a user, created using the `createUserWithEmailAndPassword` method, has their email verified. This PR allows changing the default behaviour using the exposed MockFirebaseAuth parameter `verifyEmailAutomatically`:

```
  MockFirebaseAuth({
    bool signedIn = false,
    MockUser? mockUser,
    Map<String, List<String>>? signInMethodsForEmail,
    bool verifyEmailAutomatically = true
  })
```