### PR TITLE
fixed compilation issues from upstream breaking changes

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -131,11 +131,15 @@ class MockFirebaseAuth implements FirebaseAuth {
       isEmailVerified: _verifyEmailAutomatically,
       displayName: 'Mock User',
       providerData: [
-        UserInfo({
-          'email': email,
-          'uid': id,
-          'providerId': 'password',
-        }),
+        UserInfo.fromPigeon(
+          PigeonUserInfo(
+            email: email,
+            uid: id,
+            providerId: 'password',
+            isAnonymous: false,
+            isEmailVerified: true
+          )
+        ),
       ],
     );
     return _fakeSignUp();

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -36,12 +36,12 @@ class MockFirebaseAuth implements FirebaseAuth {
   @override
   FirebaseApp app;
 
-  MockFirebaseAuth({
-    bool signedIn = false,
-    MockUser? mockUser,
-    Map<String, List<String>>? signInMethodsForEmail,
-    bool verifyEmailAutomatically = true
-  })  : _mockUser = mockUser,
+  MockFirebaseAuth(
+      {bool signedIn = false,
+      MockUser? mockUser,
+      Map<String, List<String>>? signInMethodsForEmail,
+      bool verifyEmailAutomatically = true})
+      : _mockUser = mockUser,
         _verifyEmailAutomatically = verifyEmailAutomatically,
         _signInMethodsForEmail = signInMethodsForEmail ?? {},
         app = MockFirebaseApp() {
@@ -131,15 +131,12 @@ class MockFirebaseAuth implements FirebaseAuth {
       isEmailVerified: _verifyEmailAutomatically,
       displayName: 'Mock User',
       providerData: [
-        UserInfo.fromPigeon(
-          PigeonUserInfo(
+        UserInfo.fromPigeon(PigeonUserInfo(
             email: email,
             uid: id,
             providerId: 'password',
             isAnonymous: false,
-            isEmailVerified: _verifyEmailAutomatically
-          )
-        ),
+            isEmailVerified: _verifyEmailAutomatically)),
       ],
     );
     return _fakeSignUp();

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -137,7 +137,7 @@ class MockFirebaseAuth implements FirebaseAuth {
             uid: id,
             providerId: 'password',
             isAnonymous: false,
-            isEmailVerified: true
+            isEmailVerified: _verifyEmailAutomatically
           )
         ),
       ],

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -94,16 +94,13 @@ class MockUser with EquatableMixin implements User {
 
   IdTokenResult getIdTokenResultSync() {
     return _idTokenResult ??
-      IdTokenResult(
-        PigeonIdTokenResult(
-          authTimestamp: 1655946582,
-          claims: _customClaim,
-          expirationTimestamp: 1656305736,
-          issuedAtTimestamp: 1656302136,
-          token: 'fake_token',
-          signInProvider: 'google.com'
-        )
-      );
+        IdTokenResult(PigeonIdTokenResult(
+            authTimestamp: 1655946582,
+            claims: _customClaim,
+            expirationTimestamp: 1656305736,
+            issuedAtTimestamp: 1656302136,
+            token: 'fake_token',
+            signInProvider: 'google.com'));
   }
 
   @override
@@ -233,14 +230,11 @@ class MockUser with EquatableMixin implements User {
     }
     maybeThrowException(this, Invocation.method(#linkWithProvider, [provider]));
     providerData.add(
-      UserInfo.fromPigeon(
-        PigeonUserInfo(
+      UserInfo.fromPigeon(PigeonUserInfo(
           providerId: provider.providerId,
           isAnonymous: false,
           isEmailVerified: _isEmailVerified,
-          uid: _uid
-        )
-      ),
+          uid: _uid)),
     );
     return Future.value(MockUserCredential(false, mockUser: this));
   }

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -94,14 +94,16 @@ class MockUser with EquatableMixin implements User {
 
   IdTokenResult getIdTokenResultSync() {
     return _idTokenResult ??
-        IdTokenResult({
-          'authTimestamp': 1655946582,
-          'claims': _customClaim,
-          'expirationTimestamp': 1656305736,
-          'issuedAtTimestamp': 1656302136,
-          'token': 'fake_token',
-          'signInProvider': 'google.com'
-        });
+      IdTokenResult(
+        PigeonIdTokenResult(
+          authTimestamp: 1655946582,
+          claims: _customClaim,
+          expirationTimestamp: 1656305736,
+          issuedAtTimestamp: 1656302136,
+          token: 'fake_token',
+          signInProvider: 'google.com'
+        )
+      );
   }
 
   @override
@@ -231,9 +233,14 @@ class MockUser with EquatableMixin implements User {
     }
     maybeThrowException(this, Invocation.method(#linkWithProvider, [provider]));
     providerData.add(
-      UserInfo({
-        'providerId': provider.providerId,
-      }),
+      UserInfo.fromPigeon(
+        PigeonUserInfo(
+          providerId: provider.providerId,
+          isAnonymous: false,
+          isEmailVerified: true,
+          uid: ''
+        )
+      ),
     );
     return Future.value(MockUserCredential(false, mockUser: this));
   }

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -237,8 +237,8 @@ class MockUser with EquatableMixin implements User {
         PigeonUserInfo(
           providerId: provider.providerId,
           isAnonymous: false,
-          isEmailVerified: true,
-          uid: ''
+          isEmailVerified: _isEmailVerified,
+          uid: _uid
         )
       ),
     );

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -3,20 +3,23 @@ import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:firebase_auth_mocks/src/mock_user_credential.dart';
+import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:mock_exceptions/mock_exceptions.dart';
 import 'package:test/test.dart';
 
-final userIdTokenResult = IdTokenResult({
-  'authTimestamp': DateTime.now().millisecondsSinceEpoch,
-  'claims': {'role': 'admin'},
-  'token': 'some_long_token',
-  'expirationTime':
-      DateTime.now().add(Duration(days: 1)).millisecondsSinceEpoch,
-  'issuedAtTimestamp':
-      DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch,
-  'signInProvider': 'phone',
-});
+final userIdTokenResult = IdTokenResult(
+  PigeonIdTokenResult(
+    authTimestamp: DateTime.now().millisecondsSinceEpoch,
+    claims: {'role': 'admin'},
+    token: 'some_long_token',
+    expirationTimestamp:
+        DateTime.now().add(Duration(days: 1)).millisecondsSinceEpoch,
+    issuedAtTimestamp:
+        DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch,
+    signInProvider: 'phone',
+  )
+);
 
 void main() {
   late MockUser tUser;
@@ -768,13 +771,13 @@ void main() {
       signedIn: true,
     );
     final decodedToken =
-        JwtDecoder.decode(await auth.currentUser!.getIdToken());
+        JwtDecoder.decode(await auth.currentUser!.getIdToken() as String);
     expect(decodedToken['role'], 'admin');
     expect(decodedToken['bodyHeight'], 169);
     await auth.signOut();
     await auth.signInWithEmailAndPassword(email: '', password: '');
     final decodedToken2 =
-        JwtDecoder.decode(await auth.currentUser!.getIdToken());
+        JwtDecoder.decode(await auth.currentUser!.getIdToken() as String);
     expect(decodedToken2['role'], 'admin');
     expect(decodedToken2['bodyHeight'], 169);
   });
@@ -784,7 +787,7 @@ void main() {
       signedIn: true,
     );
     final decodedToken =
-        JwtDecoder.decode(await auth.currentUser!.getIdToken());
+        JwtDecoder.decode(await auth.currentUser!.getIdToken() as String);
     expect(decodedToken['role'], null);
     expect(decodedToken['bodyHeight'], null);
 
@@ -792,7 +795,7 @@ void main() {
         .copyWith(customClaim: {'role': 'admin', 'bodyHeight': 169});
 
     final decodedToken2 =
-        JwtDecoder.decode(await auth.currentUser!.getIdToken());
+        JwtDecoder.decode(await auth.currentUser!.getIdToken() as String);
     expect(decodedToken2['role'], 'admin');
     expect(decodedToken2['bodyHeight'], 169);
   });

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -771,13 +771,13 @@ void main() {
       signedIn: true,
     );
     final decodedToken =
-        JwtDecoder.decode(await auth.currentUser!.getIdToken() as String);
+        JwtDecoder.decode((await auth.currentUser!.getIdToken())!);
     expect(decodedToken['role'], 'admin');
     expect(decodedToken['bodyHeight'], 169);
     await auth.signOut();
     await auth.signInWithEmailAndPassword(email: '', password: '');
     final decodedToken2 =
-        JwtDecoder.decode(await auth.currentUser!.getIdToken() as String);
+        JwtDecoder.decode((await auth.currentUser!.getIdToken())!);
     expect(decodedToken2['role'], 'admin');
     expect(decodedToken2['bodyHeight'], 169);
   });
@@ -787,7 +787,7 @@ void main() {
       signedIn: true,
     );
     final decodedToken =
-        JwtDecoder.decode(await auth.currentUser!.getIdToken() as String);
+        JwtDecoder.decode((await auth.currentUser!.getIdToken())!);
     expect(decodedToken['role'], null);
     expect(decodedToken['bodyHeight'], null);
 
@@ -795,7 +795,7 @@ void main() {
         .copyWith(customClaim: {'role': 'admin', 'bodyHeight': 169});
 
     final decodedToken2 =
-        JwtDecoder.decode(await auth.currentUser!.getIdToken() as String);
+        JwtDecoder.decode((await auth.currentUser!.getIdToken())!);
     expect(decodedToken2['role'], 'admin');
     expect(decodedToken2['bodyHeight'], 169);
   });

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -8,18 +8,16 @@ import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:mock_exceptions/mock_exceptions.dart';
 import 'package:test/test.dart';
 
-final userIdTokenResult = IdTokenResult(
-  PigeonIdTokenResult(
-    authTimestamp: DateTime.now().millisecondsSinceEpoch,
-    claims: {'role': 'admin'},
-    token: 'some_long_token',
-    expirationTimestamp:
-        DateTime.now().add(Duration(days: 1)).millisecondsSinceEpoch,
-    issuedAtTimestamp:
-        DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch,
-    signInProvider: 'phone',
-  )
-);
+final userIdTokenResult = IdTokenResult(PigeonIdTokenResult(
+  authTimestamp: DateTime.now().millisecondsSinceEpoch,
+  claims: {'role': 'admin'},
+  token: 'some_long_token',
+  expirationTimestamp:
+      DateTime.now().add(Duration(days: 1)).millisecondsSinceEpoch,
+  issuedAtTimestamp:
+      DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch,
+  signInProvider: 'phone',
+));
 
 void main() {
   late MockUser tUser;
@@ -78,7 +76,8 @@ void main() {
       expect(user.emailVerified, isTrue);
     });
 
-    test('with email and password without email verification by default', () async {
+    test('with email and password without email verification by default',
+        () async {
       final email = 'some@email.com';
       final password = 'some!password';
       final auth = MockFirebaseAuth(verifyEmailAutomatically: false);
@@ -97,7 +96,6 @@ void main() {
       expect(user.isAnonymous, isFalse);
       expect(user.emailVerified, isFalse);
     });
-
   });
 
   group('Returns a mocked user after sign in', () {


### PR DESCRIPTION
A few contracts changed in dependent libraries that broke the mocks library. was able to reproduce simply by pulling latest and running tests which showed numerous compilation problems. After these proposed changes, all tests pass.

These were the problem areas:
- UserInfo constructor
- IdTokenResult constructor
- JwtDecoder.decode