### PR TITLE
update uuid package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.3.0
   equatable: ^2.0.0
   dart_jsonwebtoken: ^2.4.1
-  uuid: ^3.0.6
+  uuid: ^4.1.0
   firebase_auth_platform_interface: ^6.16.0
   mock_exceptions: ^0.8.2
 


### PR DESCRIPTION
My team's project relies on both the 4.x version of the uuid package and firebase_auth_mocks, so I updated the uuid package in this repository.