### PR TITLE
Upgrade dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   meta: ^1.3.0
   equatable: ^2.0.0
   dart_jsonwebtoken: ^2.4.1
-  uuid: ^3.0.6
-  firebase_auth_platform_interface: ^6.16.0
+  uuid: ^4.1.0
+  firebase_auth_platform_interface: ^7.0.0
   mock_exceptions: ^0.8.2
 
 dev_dependencies:


### PR DESCRIPTION
Upgrade the following packages to the latest major version:
- `uuid`
- `firebase_auth_platform_interface`

Please release ASAP as this interferes with other packages. There seem to be no breaking changes within this package.