### PR TITLE
Allow throwing mock exceptions from signOut

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -165,6 +165,8 @@ class MockFirebaseAuth implements FirebaseAuth {
 
   @override
   Future<void> signOut() async {
+    maybeThrowException(this, Invocation.method(#signOut, [null]));
+
     _currentUser = null;
     stateChangedStreamController.add(null);
     userChangedStreamController.add(null);

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -429,6 +429,17 @@ void main() {
       );
     });
 
+    test('signOut', () async {
+      final auth = MockFirebaseAuth();
+      whenCalling(Invocation.method(#signOut, null))
+          .on(auth)
+          .thenThrow(FirebaseAuthException(code: 'bla'));
+      expect(
+        () => auth.signOut(),
+        throwsA(isA<FirebaseAuthException>()),
+      );
+    });
+
     test('fetchSignInMethodsForEmail', () async {
       final auth = MockFirebaseAuth();
       whenCalling(Invocation.method(


### PR DESCRIPTION
Resolves https://github.com/atn832/firebase_auth_mocks/issues/109.

Seems like it was very straightforward, but let me know if there's anything I've missed!