### PR TITLE
Allow setting mock user to `null`

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -61,11 +61,11 @@ class MockFirebaseAuth implements FirebaseAuth {
       }
     } else {
       // Notify of null on startup.
-      signOut();
+      _notifyCredential(null);
     }
   }
 
-  set mockUser(MockUser user) {
+  set mockUser(MockUser? user) {
     _mockUser = user;
     // Update _currentUser if already sign in
     if (_currentUser != null) {
@@ -165,10 +165,8 @@ class MockFirebaseAuth implements FirebaseAuth {
 
   @override
   Future<void> signOut() async {
-    _currentUser = null;
-    stateChangedStreamController.add(null);
-    userChangedStreamController.add(null);
-    authForFakeFirestoreStreamController.add(null);
+    mockUser = null;
+    _notifyCredential(null);
   }
 
   @override
@@ -182,20 +180,29 @@ class MockFirebaseAuth implements FirebaseAuth {
   Future<UserCredential> _fakeSignIn({bool isAnonymous = false}) async {
     final userCredential = MockUserCredential(isAnonymous, mockUser: _mockUser);
     _currentUser = userCredential.user;
-    stateChangedStreamController.add(_currentUser);
-    userChangedStreamController.add(_currentUser);
-    final u = userCredential.mockUser;
-    authForFakeFirestoreStreamController.add({
-      'uid': u.uid,
-      'token': {
-        'name': u.displayName,
-        'email': u.email,
-        'email_verified': u.emailVerified,
-        'firebase.sign_in_provider': u.getIdTokenResultSync().signInProvider,
-        ...u.getIdTokenResultSync().claims ?? {}
-      }
-    });
+    _notifyCredential(userCredential);
     return Future.value(userCredential);
+  }
+
+  void _notifyCredential(MockUserCredential? credential) {
+    final user = credential?.user;
+    stateChangedStreamController.add(user);
+    userChangedStreamController.add(user);
+
+    final mockUser = credential?.mockUser;
+    authForFakeFirestoreStreamController.add(mockUser == null
+        ? null
+        : {
+            'uid': mockUser.uid,
+            'token': {
+              'name': mockUser.displayName,
+              'email': mockUser.email,
+              'email_verified': mockUser.emailVerified,
+              'firebase.sign_in_provider':
+                  mockUser.getIdTokenResultSync().signInProvider,
+              ...mockUser.getIdTokenResultSync().claims ?? {}
+            }
+          });
   }
 
   Future<UserCredential> _fakeSignUp({bool isAnonymous = false}) {

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -167,6 +167,7 @@ class MockFirebaseAuth implements FirebaseAuth {
   Future<void> signOut() async {
     maybeThrowException(this, Invocation.method(#signOut, [null]));
 
+    _currentUser = null;
     _notifyCredential(null);
   }
 

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -167,7 +167,6 @@ class MockFirebaseAuth implements FirebaseAuth {
   Future<void> signOut() async {
     maybeThrowException(this, Invocation.method(#signOut, [null]));
 
-    mockUser = null;
     _notifyCredential(null);
   }
 

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -240,6 +240,17 @@ void main() {
   });
 
   group('Sign out', () {
+    test('Returns null after sign out', () async {
+      final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
+      final user = auth.currentUser;
+
+      await auth.signOut();
+
+      expect(auth.currentUser, isNull);
+      expect(auth.authStateChanges(), emitsInOrder([user, null]));
+      expect(auth.userChanges(), emitsInOrder([user, null]));
+    });
+
     test('Can sign in again after sign out', () async {
       final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
       final user = auth.currentUser;

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -813,8 +813,6 @@ void main() {
     expect(decodedToken['role'], 'admin');
     expect(decodedToken['bodyHeight'], 169);
     await auth.signOut();
-
-    auth.mockUser = user;
     await auth.signInWithEmailAndPassword(email: '', password: '');
     final decodedToken2 =
         JwtDecoder.decode((await auth.currentUser!.getIdToken())!);

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -240,17 +240,6 @@ void main() {
   });
 
   group('Sign out', () {
-    test('Returns null after sign out', () async {
-      final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
-      final user = auth.currentUser;
-
-      await auth.signOut();
-
-      expect(auth.currentUser, isNull);
-      expect(auth.authStateChanges(), emitsInOrder([user, null]));
-      expect(auth.userChanges(), emitsInOrder([user, null]));
-    });
-
     test('Can sign in again after sign out', () async {
       final auth = MockFirebaseAuth(signedIn: true, mockUser: tUser);
       final user = auth.currentUser;
@@ -270,6 +259,8 @@ void main() {
       final user = auth.currentUser;
 
       await auth.signOut();
+
+      auth.mockUser = null;
       await auth.signInAnonymously();
 
       expect(auth.currentUser!.isAnonymous, isTrue);

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -806,8 +806,10 @@ void main() {
   });
 
   test('The customClaim should exist after sign-out and sign-in', () async {
-    final user = MockUser(customClaim: {'role': 'admin', 'bodyHeight': 169});
-    final auth = MockFirebaseAuth(mockUser: user, signedIn: true);
+    final auth = MockFirebaseAuth(
+      mockUser: MockUser(customClaim: {'role': 'admin', 'bodyHeight': 169}),
+      signedIn: true,
+    );
     final decodedToken =
         JwtDecoder.decode((await auth.currentUser!.getIdToken())!);
     expect(decodedToken['role'], 'admin');


### PR DESCRIPTION
Resolves https://github.com/atn832/firebase_auth_mocks/issues/110.

I've also tidied up some repeated logic when adding new user credentials to the various streams.