### PR TITLE
fix: update dependency dart_jsonwebtoken to ^3.2.0 from ^2.4.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_auth_mocks
 description: Fakes for Firebase Auth. Use this package with `google_sign_in_mocks` to write unit tests involving Firebase Authentication.
-version: 0.14.1
+version: 0.14.2
 homepage: https://www.wafrat.com
 repository: https://github.com/atn832/firebase_auth_mocks
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   firebase_core: ^3.0.0
   meta: ^1.3.0
   equatable: ^2.0.0
-  dart_jsonwebtoken: ^2.4.1
+  dart_jsonwebtoken: ^3.2.0
   uuid: ^4.1.0
   firebase_auth_platform_interface: ^7.0.0
   mock_exceptions: ^0.8.2


### PR DESCRIPTION
This PR updates the dart_jsonwebtoken dependency from ^2.4.1 to ^3.2.0.

## Why

The older version of dart_jsonwebtoken causes version resolution conflicts when trying to use popular packages like [objectbox](https://pub.dev/packages/objectbox), which require newer versions of dart_jsonwebtoken.

## What Changed
	•	Bumped dart_jsonwebtoken to ^3.2.0 in pubspec.yaml.
	•	Verified compatibility with existing code.
	•	All tests pass.

## Notes

No breaking changes were introduced in this package by the update.