### PR TITLE
Fix analyzer workflow: use latest stable version

### DIFF
--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -13,6 +13,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
       - run: flutter pub get
       - run: flutter analyze

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,5 +13,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
       - run: flutter test --test-randomize-ordering-seed 1


### PR DESCRIPTION
Issue: https://github.com/atn832/firebase_auth_mocks/actions/runs/16572842205/job/47080613191?pr=120#step:5:10
Analyzer fails with some error but running `flutter analyze` locally works. Turns out the workflow is using a different version of Flutter.

This PR makes the workflows use the latest stable Flutter version.

Based on https://github.com/subosito/flutter-action?tab=readme-ov-file#use-latest-release-for-particular-channel