### PR TITLE
Remove deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ main() {
   - `verifyPhoneNumber` resolves `codeSent`.
   - `signOut`
   - `sendPasswordResetEmail`
-  - `fetchSignInMethodsForEmail`
   - `currentUser`
-  - the ability to throw exceptions using `whenCalling(...).on(...).thenThrow(...)`. See usage details below. Currently these methods are supported: `signInWithCredential`, `signInWithPopup`, `signInWithProvider`, `signInWithEmailAndPassword`, `createUserWithEmailAndPassword`, `signInWithCustomToken`, `signInAnonymously`, `signOut`, `fetchSignInMethodsForEmail`, `sendPasswordResetEmail`, `sendSignInLinkToEmail`, `confirmPasswordReset`, `verifyPasswordResetCode`. If you need another method supported, feel free to file a ticket, or better propose a PR.
+  - the ability to throw exceptions using `whenCalling(...).on(...).thenThrow(...)`. See usage details below. Currently these methods are supported: `signInWithCredential`, `signInWithPopup`, `signInWithProvider`, `signInWithEmailAndPassword`, `createUserWithEmailAndPassword`, `signInWithCustomToken`, `signInAnonymously`, `signOut`, `sendPasswordResetEmail`, `sendSignInLinkToEmail`, `confirmPasswordReset`, `verifyPasswordResetCode`. If you need another method supported, feel free to file a ticket, or better propose a PR.
   - pass auth information (uid, custom claims...) to Fake Cloud Firestore for security rules via `authForFakeFirestore`. See the docs at [fake_cloud_firestore](https://pub.dev/packages/fake_cloud_firestore#security-rules) for usage.
 - `UserCredential` contains the provided `User` with the information of your choice.
 - `User` supports:
@@ -82,13 +81,12 @@ expect(
 
 ```dart
 final auth = MockFirebaseAuth();
-whenCalling(Invocation.method(
-        #fetchSignInMethodsForEmail, ['someone@somewhere.com']))
+whenCalling(Invocation.method(#verifyPhoneNumber, '12-345-6789'))
     .on(auth)
-    .thenThrow(FirebaseAuthException(code: 'bla'));
-expect(() => auth.fetchSignInMethodsForEmail('someone@somewhere.com'),
+    .thenThrow(FirebaseAuthException(code: 'invalid-action-code'));
+expect(() => auth.verifyPhoneNumber('12-345-6789'),
     throwsA(isA<FirebaseAuthException>()));
-expect(() => auth.fetchSignInMethodsForEmail('someoneelse@somewhereelse.com'),
+expect(() => auth.verifyPhoneNumber('00-222-4444'),
     returnsNormally);
 ```
 
@@ -99,13 +97,23 @@ Supports all of the matchers from the [Dart matchers library](https://api.flutte
 ```dart
 final auth = MockFirebaseAuth();
 whenCalling(Invocation.method(
-        #fetchSignInMethodsForEmail, [endsWith('@somewhere.com')]))
+        #confirmPasswordReset, null, {#code: contains('code')}))
     .on(auth)
-    .thenThrow(FirebaseAuthException(code: 'bla'));
-expect(() => auth.fetchSignInMethodsForEmail('someone@somewhere.com'),
-    throwsA(isA<FirebaseAuthException>()));
-expect(() => auth.fetchSignInMethodsForEmail('someoneelse@somewhereelse.com'),
-    returnsNormally);
+    .thenThrow(FirebaseAuthException(code: 'invalid-action-code'));
+expect(
+  () => auth.confirmPasswordReset(
+    code: 'code',
+    newPassword: 'password',
+  ),
+  throwsA(isA<FirebaseAuthException>()),
+);
+expect(
+  () => auth.confirmPasswordReset(
+    code: '1234',
+    newPassword: 'password',
+  ),
+  returnsNormally,
+);
 ```
 
 ### Depending on named parameters

--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -171,14 +171,6 @@ class MockFirebaseAuth implements FirebaseAuth {
     _notifyCredential(null);
   }
 
-  @override
-  Future<List<String>> fetchSignInMethodsForEmail(String email) {
-    maybeThrowException(
-        this, Invocation.method(#fetchSignInMethodsForEmail, [email]));
-
-    return Future.value(_signInMethodsForEmail[email] ?? []);
-  }
-
   Future<UserCredential> _fakeSignIn({bool isAnonymous = false}) async {
     final userCredential = MockUserCredential(isAnonymous, mockUser: _mockUser);
     _currentUser = userCredential.user;

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -470,20 +470,6 @@ void main() {
       );
     });
 
-    test('fetchSignInMethodsForEmail', () async {
-      final auth = MockFirebaseAuth();
-      whenCalling(Invocation.method(
-              #fetchSignInMethodsForEmail, ['someone@somewhere.com']))
-          .on(auth)
-          .thenThrow(FirebaseAuthException(code: 'bla'));
-      expect(() => auth.fetchSignInMethodsForEmail('someone@somewhere.com'),
-          throwsA(isA<FirebaseAuthException>()));
-      expect(
-          () =>
-              auth.fetchSignInMethodsForEmail('someoneelse@somewhereelse.com'),
-          returnsNormally);
-    });
-
     test('sendPasswordResetEmail', () async {
       final auth = MockFirebaseAuth();
       whenCalling(Invocation.method(#sendPasswordResetEmail, null))
@@ -815,16 +801,6 @@ void main() {
     expect(decodedToken['auth_time'],
         customAuthTime.millisecondsSinceEpoch ~/ 1000);
     expect(decodedToken['exp'], customExp.millisecondsSinceEpoch ~/ 1000);
-  });
-
-  test('Set up fetchSignInMethodsForEmail results', () async {
-    final auth = MockFirebaseAuth(
-      signInMethodsForEmail: {
-        'test@example.com': ['password']
-      },
-    );
-    expect(await auth.fetchSignInMethodsForEmail('test@example.com'),
-        equals(['password']));
   });
 
   test('Add customClaim into id token', () async {


### PR DESCRIPTION
Turns out the analyzer failure in #120 wasn't because of the Flutter running analyzer. fetchSignInMethodsForEmail was removed in firebase_auth 6.0.0. https://pub.dev/packages/firebase_auth/changelog#600