### PR TITLE
Update firebase_auth_platform_interface + Pigeon

### DIFF
--- a/lib/src/firebase_auth_mocks_base.dart
+++ b/lib/src/firebase_auth_mocks_base.dart
@@ -133,7 +133,7 @@ class MockFirebaseAuth implements FirebaseAuth {
       isEmailVerified: _verifyEmailAutomatically,
       displayName: 'Mock User',
       providerData: [
-        UserInfo.fromPigeon(PigeonUserInfo(
+        UserInfo.fromPigeon(InternalUserInfo(
             email: email,
             uid: id,
             providerId: 'password',

--- a/lib/src/mock_user.dart
+++ b/lib/src/mock_user.dart
@@ -98,7 +98,7 @@ class MockUser with EquatableMixin implements User {
 
   IdTokenResult getIdTokenResultSync() {
     return _idTokenResult ??
-        IdTokenResult(PigeonIdTokenResult(
+        IdTokenResult(InternalIdTokenResult (
             authTimestamp: 1655946582,
             claims: _customClaim,
             expirationTimestamp: 1656305736,
@@ -234,7 +234,7 @@ class MockUser with EquatableMixin implements User {
     }
     maybeThrowException(this, Invocation.method(#linkWithProvider, [provider]));
     providerData.add(
-      UserInfo.fromPigeon(PigeonUserInfo(
+      UserInfo.fromPigeon(InternalUserInfo(
           providerId: provider.providerId,
           isAnonymous: false,
           isEmailVerified: _isEmailVerified,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_auth_mocks
 description: Fakes for Firebase Auth. Use this package with `google_sign_in_mocks` to write unit tests involving Firebase Authentication.
-version: 0.15.1
+version: 0.15.2
 homepage: https://www.wafrat.com
 repository: https://github.com/atn832/firebase_auth_mocks
 
@@ -16,7 +16,7 @@ dependencies:
   equatable: ^2.0.0
   dart_jsonwebtoken: ^3.2.0
   uuid: ^4.1.0
-  firebase_auth_platform_interface: ^8.0.0
+  firebase_auth_platform_interface: ^9.0.0
   mock_exceptions: ^0.8.2
 
 dev_dependencies:

--- a/test/firebase_auth_mocks_test.dart
+++ b/test/firebase_auth_mocks_test.dart
@@ -8,7 +8,7 @@ import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:mock_exceptions/mock_exceptions.dart';
 import 'package:test/test.dart';
 
-final userIdTokenResult = IdTokenResult(PigeonIdTokenResult(
+final userIdTokenResult = IdTokenResult(InternalIdTokenResult(
   authTimestamp: DateTime.now().millisecondsSinceEpoch,
   claims: {'role': 'admin'},
   token: 'some_long_token',


### PR DESCRIPTION
Simple fix for upgrading the firebase_auth_platform_interface major version to 9.x and used the newly renamed internal objects. Tests are passing. @atn832 